### PR TITLE
Add $arg_seperator to http_build_query

### DIFF
--- a/src/Omnipay/PayPal/Message/AbstractRequest.php
+++ b/src/Omnipay/PayPal/Message/AbstractRequest.php
@@ -117,7 +117,7 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
 
     public function sendData($data)
     {
-        $url = $this->getEndpoint().'?'.http_build_query($data);
+        $url = $this->getEndpoint().'?'.http_build_query($data, '', '&');
         $httpResponse = $this->httpClient->get($url)->send();
 
         return $this->createResponse($httpResponse->getBody());

--- a/src/Omnipay/PayPal/Message/ExpressAuthorizeResponse.php
+++ b/src/Omnipay/PayPal/Message/ExpressAuthorizeResponse.php
@@ -29,8 +29,7 @@ class ExpressAuthorizeResponse extends Response implements RedirectResponseInter
                 'cmd' => '_express-checkout',
                 'useraction' => 'commit',
                 'token' => $this->getTransactionReference(),
-            )
-        );
+            ), '', '&');
     }
 
     public function getTransactionReference()


### PR DESCRIPTION
Added $arg_seperator to http_build_query in order to circumvent
PayPal-Authentication-Errors because of „&amp“ instead of „&“ on some
servers (see
http://www.php.net/manual/en/function.http-build-query.php#102324)
