### PR TITLE
Add support for BRANDNAME

### DIFF
--- a/src/Omnipay/PayPal/ExpressGateway.php
+++ b/src/Omnipay/PayPal/ExpressGateway.php
@@ -46,6 +46,16 @@ class ExpressGateway extends ProGateway
         return $this->setParameter('landingPage', $value);
     }
 
+    public function getBrandName()
+    {
+        return $this->getParameter('brandName');
+    }
+
+    public function setBrandName($value)
+    {
+        return $this->setParameter('brandName', $value);
+    }
+
     public function getHeaderImageUrl()
     {
         return $this->getParameter('headerImageUrl');

--- a/src/Omnipay/PayPal/Message/AbstractRequest.php
+++ b/src/Omnipay/PayPal/Message/AbstractRequest.php
@@ -82,6 +82,16 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
         return $this->setParameter('headerImageUrl', $value);
     }
 
+    public function getBrandName()
+    {
+        return $this->getParameter('brandName');
+    }
+
+    public function setBrandName($value)
+    {
+        return $this->setParameter('brandName', $value);
+    }
+
     public function getNoShipping()
     {
         return $this->getParameter('noShipping');

--- a/src/Omnipay/PayPal/Message/ExpressAuthorizeRequest.php
+++ b/src/Omnipay/PayPal/Message/ExpressAuthorizeRequest.php
@@ -30,6 +30,10 @@ class ExpressAuthorizeRequest extends AbstractRequest
             $data['HDRIMG'] = $headerImageUrl;
         }
 
+        if ($brandName = $this->getBrandName()) {
+            $data['BRANDNAME'] = $brandName;
+        }
+
         if (null !== ($noShipping = $this->getNoShipping())) {
             $data['NOSHIPPING'] = $noShipping;
         }

--- a/tests/Omnipay/PayPal/Message/ExpressAuthorizeRequestTest.php
+++ b/tests/Omnipay/PayPal/Message/ExpressAuthorizeRequestTest.php
@@ -40,6 +40,7 @@ class ExpressAuthorizeRequestTest extends TestCase
             'headerImageUrl' => 'https://www.example.com/header.jpg',
             'noShipping' => 0,
             'allowNote' => 0,
+            'brandName' => 'Dunder Mifflin Paper Company, Inc.',
         ));
 
         $data = $this->request->getData();
@@ -55,6 +56,7 @@ class ExpressAuthorizeRequestTest extends TestCase
         $this->assertSame('https://www.example.com/header.jpg', $data['HDRIMG']);
         $this->assertSame(0, $data['NOSHIPPING']);
         $this->assertSame(0, $data['ALLOWNOTE']);
+        $this->assertSame('Dunder Mifflin Paper Company, Inc.', $data['BRANDNAME']);
     }
 
     public function testGetDataWithCard()
@@ -71,6 +73,7 @@ class ExpressAuthorizeRequestTest extends TestCase
             'headerImageUrl' => 'https://www.example.com/header.jpg',
             'noShipping' => 2,
             'allowNote' => 1,
+            'brandName' => 'Dunder Mifflin Paper Company, Inc.',
         ));
 
         $card = new CreditCard(array(
@@ -115,6 +118,7 @@ class ExpressAuthorizeRequestTest extends TestCase
             'PAYMENTREQUEST_0_SHIPTOZIP' => '66605',
             'PAYMENTREQUEST_0_SHIPTOPHONENUM' => '555-555-5555',
             'EMAIL' => 'test@email.com',
+            'BRANDNAME' => 'Dunder Mifflin Paper Company, Inc.',
         );
 
         $this->assertEquals($expected, $this->request->getData());


### PR DESCRIPTION
PayPal Express Checkout allows you to optionally send your company/brand name to customize the header (if you aren't using a header image) and the cancel link on the PayPal checkout page (see image below). This PR adds support for setting the brand name.

![pay_with_a_paypal_account-5](https://f.cloud.github.com/assets/755001/2201257/9884b978-98ec-11e3-8300-eb2a5de30db9.png)
