### PR TITLE
Send item data during express complete call

### DIFF
--- a/src/Omnipay/PayPal/Message/AbstractRequest.php
+++ b/src/Omnipay/PayPal/Message/AbstractRequest.php
@@ -125,6 +125,22 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
         return $data;
     }
 
+    protected function getItemData()
+    {
+        $data = array();
+        $items = $this->getItems();
+        if ($items) {
+            foreach ($items as $n => $item) {
+                $data["L_PAYMENTREQUEST_0_NAME$n"] = $item->getName();
+                $data["L_PAYMENTREQUEST_0_DESC$n"] = $item->getDescription();
+                $data["L_PAYMENTREQUEST_0_QTY$n"] = $item->getQuantity();
+                $data["L_PAYMENTREQUEST_0_AMT$n"] = $this->formatCurrency($item->getPrice());
+            }
+        }
+
+        return $data;
+    }
+
     public function sendData($data)
     {
         $url = $this->getEndpoint().'?'.http_build_query($data, '', '&');

--- a/src/Omnipay/PayPal/Message/ExpressAuthorizeRequest.php
+++ b/src/Omnipay/PayPal/Message/ExpressAuthorizeRequest.php
@@ -43,15 +43,8 @@ class ExpressAuthorizeRequest extends AbstractRequest
             $data['EMAIL'] = $card->getEmail();
         }
 
-        $items = $this->getItems();
-        if ($items) {
-            foreach ($items as $n => $item) {
-                $data["L_PAYMENTREQUEST_0_NAME$n"] = $item->getName();
-                $data["L_PAYMENTREQUEST_0_DESC$n"] = $item->getDescription();
-                $data["L_PAYMENTREQUEST_0_QTY$n"] = $item->getQuantity();
-                $data["L_PAYMENTREQUEST_0_AMT$n"] = $this->formatCurrency($item->getPrice());
-            }
-        }
+        $itemData = $this->getItemData();
+        $data = array_merge($data, $itemData);
 
         return $data;
     }

--- a/src/Omnipay/PayPal/Message/ExpressCompleteAuthorizeRequest.php
+++ b/src/Omnipay/PayPal/Message/ExpressCompleteAuthorizeRequest.php
@@ -24,6 +24,9 @@ class ExpressCompleteAuthorizeRequest extends AbstractRequest
         $data['TOKEN'] = $this->httpRequest->query->get('token');
         $data['PAYERID'] = $this->httpRequest->query->get('PayerID');
 
+        $itemData = $this->getItemData();
+        $data = array_merge($data, $itemData);
+
         return $data;
     }
 }

--- a/tests/Omnipay/PayPal/Message/ExpressCompleteAuthorizeRequestTest.php
+++ b/tests/Omnipay/PayPal/Message/ExpressCompleteAuthorizeRequestTest.php
@@ -51,4 +51,32 @@ class ExpressCompleteAuthorizeRequestTest extends TestCase
 
         $this->assertEquals($expected, $this->request->getData());
     }
+
+    public function testGetDataWithItems()
+    {
+        $this->request->setAmount('50.00');
+        $this->request->setCurrency('USD');
+        $this->request->setTransactionId('ABC-123');
+        $this->request->setUsername('testuser');
+        $this->request->setPassword('testpass');
+        $this->request->setSignature('SIG');
+        $this->request->setSubject('SUB');
+        $this->request->setDescription('DESC');
+
+        $this->request->setItems(array(
+            array('name' => 'Floppy Disk', 'description' => 'MS-DOS', 'quantity' => 2, 'price' => 10),
+            array('name' => 'CD-ROM', 'description' => 'Windows 95', 'quantity' => 1, 'price' => 40),
+        ));
+
+        $data = $this->request->getData();
+        $this->assertSame('Floppy Disk', $data['L_PAYMENTREQUEST_0_NAME0']);
+        $this->assertSame('MS-DOS', $data['L_PAYMENTREQUEST_0_DESC0']);
+        $this->assertSame(2, $data['L_PAYMENTREQUEST_0_QTY0']);
+        $this->assertSame('10.00', $data['L_PAYMENTREQUEST_0_AMT0']);
+
+        $this->assertSame('CD-ROM', $data['L_PAYMENTREQUEST_0_NAME1']);
+        $this->assertSame('Windows 95', $data['L_PAYMENTREQUEST_0_DESC1']);
+        $this->assertSame(1, $data['L_PAYMENTREQUEST_0_QTY1']);
+        $this->assertSame('40.00', $data['L_PAYMENTREQUEST_0_AMT1']);
+    }
 }


### PR DESCRIPTION
Items can also be sent with the complete authorize request when using express checkout, and doing so ensures that the invoice / email notification to the customer includes an itemized list of what they purchased.

Wasn't sure the best way to go about this, so I added it to getBaseData to prevent code duplication.
