### PR TITLE
Add line items to request

### DIFF
--- a/src/Message/ExpressCompleteAuthorizeRequest.php
+++ b/src/Message/ExpressCompleteAuthorizeRequest.php
@@ -20,6 +20,16 @@ class ExpressCompleteAuthorizeRequest extends AbstractRequest
         $data['PAYMENTREQUEST_0_DESC'] = $this->getDescription();
         $data['PAYMENTREQUEST_0_NOTIFYURL'] = $this->getNotifyUrl();
 
+        $items = $this->getItems();
+        if ($items) {
+            foreach ($items as $n => $item) {
+                $data["L_PAYMENTREQUEST_0_NAME$n"] = $item->getName();
+                $data["L_PAYMENTREQUEST_0_DESC$n"] = $item->getDescription();
+                $data["L_PAYMENTREQUEST_0_QTY$n"] = $item->getQuantity();
+                $data["L_PAYMENTREQUEST_0_AMT$n"] = $this->formatCurrency($item->getPrice());
+            }
+        }
+
         $data['TOKEN'] = $this->httpRequest->query->get('token');
         $data['PAYERID'] = $this->httpRequest->query->get('PayerID');
 


### PR DESCRIPTION
When adding line items to your PayPal Express checkout, the line items display in PayPal's payment page just fine and the transaction completes successfully. Awesome.

However, since the items aren't included in the Complete Purchase Request, the line items don't appear in PayPal's email receipt.

This PR allows the line items to appear in the email.

The code was copied directly from `ExpressAuthorizeRequest`

I don't know much about writing tests and I couldn't see any tests for the existing line items code anyway.
