### PR TITLE
updated branch alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "2.0.x-dev"
+            "dev-master": "2.3.x-dev"
         }
     }
 }


### PR DESCRIPTION
So that we don't have to explicitely use "dev-master" in order to grab the latest changes.
