### PR TITLE
AbstractRequest amounts MUST include decimals if the currency supports decimals.

### DIFF
--- a/tests/Message/RefundRequestTest.php
+++ b/tests/Message/RefundRequestTest.php
@@ -43,7 +43,8 @@ class RefundRequestTest extends TestCase
         $expected['SIGNATURE'] = 'SIG';
         $expected['SUBJECT'] = 'SUB';
         $expected['VERSION'] = RefundRequest::API_VERSION;
-        if ($amount) {
+        // $amount will be a formatted string, and '0.00' evaluates to true
+        if ((float)$amount) {
             $expected['AMT'] = $amount;
             $expected['CURRENCYCODE'] = 'USD';
         }
@@ -55,6 +56,7 @@ class RefundRequestTest extends TestCase
     {
         return array(
             'Partial' => array('Partial', '1.23'),
+            // All amounts must include decimals or be a float if the currency supports decimals.
             'Full' => array('Full', '0.00'),
         );
     }


### PR DESCRIPTION
Issue tracked here: https://github.com/thephpleague/omnipay-common/issues/17

This rule is to catch issues with legacy code from OmniPay v0.9 OmniPay internally will always return getAmount() as a string formatted to the number of decimal places the currency requires. A gateway that requires a different format (e.g. cents with no decimal rather than dollars) would do the conversion, or overwrite getAmount()
