### PR TITLE
Accept paypal payments

### DIFF
--- a/src/Message/RestAuthorizeRequest.php
+++ b/src/Message/RestAuthorizeRequest.php
@@ -66,11 +66,47 @@ namespace Omnipay\PayPal\Message;
  * As of January 2015 these transactions are only supported in the UK
  * and in the USA.
  *
+ * Example 2, with PayPal as the payment method:
+ *
+ * <code>
+ *   // Create a gateway for the PayPal RestGateway
+ *   // (routes to GatewayFactory::create)
+ *   $gateway = Omnipay::create('RestGateway');
+ *
+ *   // Initialise the gateway
+ *   $gateway->initialize(array(
+ *       'clientId' => 'MyPayPalClientId',
+ *       'secret'   => 'MyPayPalSecret',
+ *       'testMode' => true, // Or false when you are ready for live transactions
+ *   ));
+ *
+ *   // Do an authorize transaction on the gateway
+ *   $transaction = $gateway->authorize(array(
+ *       'amount'        => '10.00',
+ *       'currency'      => 'AUD',
+ *       'description'   => 'This is a test authorize transaction.',
+ *   ))->setReturnUrl('http://www.example.com/your_return_url/')
+ *     ->setCancelUrl('http://www.example.com/your_cancel_url/');
+ *   $response = $transaction->send();
+ *   if ($response->isSuccessful()) {
+ *       echo "Authorize transaction was successful!\n";
+ *       if ($response->isRedirect()) {
+ *           echo "Response is a redirect.\n";
+ *           echo "Redirect URL == " . $response->getRedirectUrl() .
+ *                " method == " . $response->getRedirectMethod() . "\n";
+ *       }
+ *   }
+ * </code>
+ *
+ * In this second example you would need to execute the authorization
+ * before doing a capture.  See RestExecuteRequest.
+ *
  * @link https://developer.paypal.com/docs/integration/direct/capture-payment/#authorize-the-payment
  * @link https://developer.paypal.com/docs/api/#authorizations
  * @link http://bit.ly/1wUQ33R
  * @see RestCaptureRequest
  * @see RestPurchaseRequest
+ * @see RestExecuteRequest
  */
 class RestAuthorizeRequest extends AbstractRestRequest
 {

--- a/src/Message/RestAuthorizeRequest.php
+++ b/src/Message/RestAuthorizeRequest.php
@@ -66,10 +66,6 @@ namespace Omnipay\PayPal\Message;
  * As of January 2015 these transactions are only supported in the UK
  * and in the USA.
  *
- * TODO: This class only works for direct credit card payments.  It should
- * be able to be made to work for PayPal payments too (by changing the
- * payer/payment_method parameter and adding linkback URLs). 
- *
  * @link https://developer.paypal.com/docs/integration/direct/capture-payment/#authorize-the-payment
  * @link https://developer.paypal.com/docs/api/#authorizations
  * @link http://bit.ly/1wUQ33R

--- a/src/Message/RestExecuteRequest.php
+++ b/src/Message/RestExecuteRequest.php
@@ -137,6 +137,6 @@ class RestExecuteRequest extends AbstractRestRequest
      */
     protected function getEndpoint()
     {
-        return parent::getEndpoint() . '/payments/payment/' . $this->getPaymentId() . '/execute;
+        return parent::getEndpoint() . '/payments/payment/' . $this->getPaymentId() . '/execute';
     }
 }

--- a/src/Message/RestExecuteRequest.php
+++ b/src/Message/RestExecuteRequest.php
@@ -37,8 +37,6 @@ namespace Omnipay\PayPal\Message;
  *   echo "Gateway execute response data == " . print_r($data, true) . "\n";
  * </code>
  *
- * TODO: Need a test case.
- *
  * @link https://developer.paypal.com/docs/integration/direct/capture-payment/#authorize-the-payment
  * @link https://developer.paypal.com/docs/api/#execute-an-approved-paypal-payment
  * @see RestAuthorizeRequest

--- a/src/Message/RestExecuteRequest.php
+++ b/src/Message/RestExecuteRequest.php
@@ -37,8 +37,6 @@ namespace Omnipay\PayPal\Message;
  *   echo "Gateway execute response data == " . print_r($data, true) . "\n";
  * </code>
  *
- * TODO: I'm not sure how this works for PayPal authorizations.
- *
  * TODO: Need a test case.
  *
  * @link https://developer.paypal.com/docs/integration/direct/capture-payment/#authorize-the-payment
@@ -131,7 +129,9 @@ class RestExecuteRequest extends AbstractRestRequest
     /**
      * Get transaction endpoint.
      *
-     * Authorization of payments is done using the /payment resource.
+     * Execution of payments is done using the /payment resource.  Note
+     * that executions of authorize transactions and executions of payment
+     * transactions are both done using the /payment resource.
      *
      * @return string
      */

--- a/src/Message/RestExecuteRequest.php
+++ b/src/Message/RestExecuteRequest.php
@@ -1,0 +1,142 @@
+<?php
+/**
+ * PayPal REST Execute Request
+ */
+
+namespace Omnipay\PayPal\Message;
+
+/**
+ * PayPal REST Execute Request
+ *
+ * This is used to execute payment requests for payer.payment_method = paypal.
+ *
+ * When the user approves the payment, PayPal redirects the user to the return_url
+ * that was specified when the payment was created. A payer Id and payment Id
+ * are appended to the return URL, as PayerID and paymentId:
+ *
+ * http://<return_url>?paymentId=PAY-6RV70583SB702805EKEYSZ6Y&token=EC-60U79048BN7719609&PayerID=7E7MGXCWTTKK2
+ *
+ * The token value appended to the return URL is not needed when you execute
+ * the payment.
+ *
+ * To execute the payment after the user’s approval, make a /payment/execute/ call.
+ * In the body of the request, use the payer_id value that was appended to the
+ * return URL. In the header, use the access token that you used when you created
+ * the payment.
+ *
+ * Example:
+ *
+ * <code>
+ *   $my_payment_id = $_GET['paymentId'];
+ *   $my_payer_id = $_GET['PayerID'];
+ *   $transaction = $gateway->execute()
+ *       ->setPaymentId($my_payment_id)
+ *       ->setPayerId($my_payer_id);
+ *   $response = $transaction->send();
+ *   $data = $response->getData();
+ *   echo "Gateway execute response data == " . print_r($data, true) . "\n";
+ * </code>
+ *
+ * TODO: I'm not sure how this works for PayPal authorizations.
+ *
+ * TODO: Need a test case.
+ *
+ * @link https://developer.paypal.com/docs/integration/direct/capture-payment/#authorize-the-payment
+ * @link https://developer.paypal.com/docs/api/#execute-an-approved-paypal-payment
+ * @see RestAuthorizeRequest
+ * @see RestPurchaseRequest
+ */
+class RestExecuteRequest extends AbstractRestRequest
+{
+    public function getData()
+    {
+        // The only data required to be sent with the execute request is
+        // the payer ID.  The payment ID is part of the execute request URL.
+        $this->validate('payerId');
+        $data = array('payer_id' => $this->getPayerId());
+
+        return $data;
+    }
+
+    /**
+     * Get Payer ID
+     *
+     * A payer Id is appended to the return URL, as PayerID
+     *
+     * @return string
+     */
+    public function getPayerId()
+    {
+        return $this->getParameter('payerId');
+    }
+
+    /**
+     * Set Payer ID
+     *
+     * A payer Id is appended to the return URL, as PayerID
+     *
+     * @return RestExecuteRequest provides a fluent interface.
+     */
+    public function setPayerId($value)
+    {
+        return $this->setParameter('payerId', $value);
+    }
+
+    /**
+     * Get Payment ID
+     *
+     * A payment Id is appended to the return URL, as paymentID
+     *
+     * @return string
+     */
+    public function getPaymentId()
+    {
+        return $this->getParameter('paymentId');
+    }
+
+    /**
+     * Set Payment ID
+     *
+     * A payment Id is appended to the return URL, as paymentID
+     *
+     * @return RestExecuteRequest provides a fluent interface.
+     */
+    public function setPaymentId($value)
+    {
+        return $this->setParameter('paymentId', $value);
+    }
+
+    /**
+     * Get transaction description.
+     *
+     * The REST API does not currently have support for passing an invoice number
+     * or transaction ID.
+     *
+     * @return string
+     */
+    public function getDescription()
+    {
+        $id = $this->getTransactionId();
+        $desc = parent::getDescription();
+
+        if (empty($id)) {
+            return $desc;
+        } elseif (empty($desc)) {
+            return $id;
+        } else {
+            return "$id : $desc";
+        }
+    }
+
+    /**
+     * Get transaction endpoint.
+     *
+     * Authorization of payments is done using the /payment resource.
+     *
+     * @return string
+     */
+    protected function getEndpoint()
+    {
+        return parent::getEndpoint() . '/payments/payment/' . $this->getPaymentId() . '/execute;
+    }
+}

--- a/src/Message/RestPurchaseRequest.php
+++ b/src/Message/RestPurchaseRequest.php
@@ -65,6 +65,11 @@ namespace Omnipay\PayPal\Message;
  *   }
  * </code>
  *
+ * Direct credit card payment and related features are restricted in
+ * some countries.
+ * As of January 2015 these transactions are only supported in the UK
+ * and in the USA.
+ *
  * Example 2, with PayPal as the payment method:
  *
  * <code>
@@ -97,13 +102,12 @@ namespace Omnipay\PayPal\Message;
  *   }
  * </code>
  *
- * Direct credit card payment and related features are restricted in
- * some countries.
- * As of January 2015 these transactions are only supported in the UK
- * and in the USA.
+ * In this second example you would need to execute the purchase at
+ * the Return URL before the payment was completed.  See RestExecuteRequest.
  *
  * @link https://developer.paypal.com/docs/api/#create-a-payment
  * @see RestAuthorizeRequest
+ * @see RestExecuteRequest
  */
 class RestPurchaseRequest extends RestAuthorizeRequest
 {

--- a/src/Message/RestPurchaseRequest.php
+++ b/src/Message/RestPurchaseRequest.php
@@ -50,7 +50,7 @@ namespace Omnipay\PayPal\Message;
  *               'billingState'          => 'QLD',
  *   ));
  *
- *   // Do an authorisation transaction on the gateway
+ *   // Do a purchase transaction on the gateway
  *   $transaction = $gateway->purchase(array(
  *       'amount'        => '10.00',
  *       'currency'      => 'AUD',
@@ -65,14 +65,42 @@ namespace Omnipay\PayPal\Message;
  *   }
  * </code>
  *
+ * Example 2, with PayPal as the payment method:
+ *
+ * <code>
+ *   // Create a gateway for the PayPal RestGateway
+ *   // (routes to GatewayFactory::create)
+ *   $gateway = Omnipay::create('RestGateway');
+ *
+ *   // Initialise the gateway
+ *   $gateway->initialize(array(
+ *       'clientId' => 'MyPayPalClientId',
+ *       'secret'   => 'MyPayPalSecret',
+ *       'testMode' => true, // Or false when you are ready for live transactions
+ *   ));
+ *
+ *   // Do a purchase transaction on the gateway
+ *   $transaction = $gateway->purchase(array(
+ *       'amount'        => '10.00',
+ *       'currency'      => 'AUD',
+ *       'description'   => 'This is a test purchase transaction.',
+ *   ))->setReturnUrl('http://www.example.com/your_return_url/')
+ *     ->setCancelUrl('http://www.example.com/your_cancel_url/');
+ *   $response = $transaction->send();
+ *   if ($response->isSuccessful()) {
+ *       echo "Purchase transaction was successful!\n";
+ *       if ($response->isRedirect()) {
+ *           echo "Response is a redirect.\n";
+ *           echo "Redirect URL == " . $response->getRedirectUrl() .
+ *                " method == " . $response->getRedirectMethod() . "\n";
+ *       }
+ *   }
+ * </code>
+ *
  * Direct credit card payment and related features are restricted in
  * some countries.
  * As of January 2015 these transactions are only supported in the UK
  * and in the USA.
- *
- * TODO: This class only works for direct credit card payments.  It should
- * be able to be made to work for PayPal payments too (by changing the
- * payer/payment_method parameter and adding linkback URLs). 
  *
  * @link https://developer.paypal.com/docs/api/#create-a-payment
  * @see RestAuthorizeRequest

--- a/src/Message/RestResponse.php
+++ b/src/Message/RestResponse.php
@@ -73,11 +73,12 @@ class RestResponse extends AbstractResponse implements RedirectResponseInterface
         }
     }
 
-    //    
+    //
     // Redirect functions -- only used when payment_method = paypal in the request.
     //
     
-    public function isRedirect() {
+    public function isRedirect()
+    {
         if (! empty($this->data['links'])) {
             foreach ($this->data['links'] as $key => $val) {
                 if ($val['rel'] = 'approval_url') {

--- a/src/RestGateway.php
+++ b/src/RestGateway.php
@@ -353,12 +353,25 @@ class RestGateway extends AbstractGateway
         return $this->createRequest('\Omnipay\PayPal\Message\RestPurchaseRequest', $parameters);
     }
 
-    // TODO: Execute an approved PayPal payment
-    //   https://developer.paypal.com/docs/api/#execute-an-approved-paypal-payment
+    /**
+     * Execute a purchase request.
+     *
+     * PayPal provides various payment related operations using the /payment
+     * resource and related sub-resources. This function executes a payment
+     * transaction where the payment type == paypal.
+     *
+     * @link https://developer.paypal.com/docs/api/#execute-an-approved-paypal-payment
+     * @param array $parameters
+     * @return \Omnipay\PayPal\Message\RestExecuteRequest
+     */
+    public function execute(array $parameters = array())
+    {
+        return $this->createRequest('\Omnipay\PayPal\Message\RestExecuteRequest', $parameters);
+    }
+
     // TODO: Look up a payment resource https://developer.paypal.com/docs/api/#look-up-a-payment-resource
     // TODO: Update a payment resource https://developer.paypal.com/docs/api/#update-a-payment-resource
     // TODO: List payment resources https://developer.paypal.com/docs/api/#list-payment-resources
-    // TODO: Payments with payment_method == paypal.
 
     //
     // Authorizations -- Capture, reauthorize, void and look up authorizations.

--- a/tests/Message/RestPurchaseRequestTest.php
+++ b/tests/Message/RestPurchaseRequestTest.php
@@ -73,4 +73,26 @@ class RestPurchaseRequestTest extends TestCase
         $this->assertSame('abc123 : Sheep', $data['transactions'][0]['description']);
         $this->assertSame('CARD-123', $data['payer']['funding_instruments'][0]['credit_card_token']['credit_card_id']);
     }
+
+    public function testGetDataWithPaypal()
+    {
+        $this->request = new RestPurchaseRequest($this->getHttpClient(), $this->getHttpRequest());
+        $this->request->initialize(array(
+            'amount' => '10.00',
+            'currency' => 'USD',
+        ))->setReturnUrl('http://www.example.com/your_return_url/')
+          ->setCancelUrl('http://www.example.com/your_cancel_url/');
+
+        $this->request->setTransactionId('abc123');
+        $this->request->setDescription('Sheep');
+        $this->request->setClientIp('127.0.0.1');
+
+        $data = $this->request->getData();
+
+        $this->assertSame('sale', $data['intent']);
+        $this->assertSame('paypal', $data['payer']['payment_method']);
+        $this->assertSame('10.00', $data['transactions'][0]['amount']['total']);
+        $this->assertSame('USD', $data['transactions'][0]['amount']['currency']);
+        $this->assertSame('abc123 : Sheep', $data['transactions'][0]['description']);
+    }
 }

--- a/tests/Message/RestResponseTest.php
+++ b/tests/Message/RestResponseTest.php
@@ -26,6 +26,16 @@ class RestResponseTest extends TestCase
         $this->assertSame('Invalid request - see details', $response->getMessage());
     }
 
+    public function testExecuteSuccess()
+    {
+        $httpResponse = $this->getMockHttpResponse('RestExecuteSuccess.txt');
+        $response = new RestResponse($this->getMockRequest(), $httpResponse->json(), $httpResponse->getStatusCode());
+
+        $this->assertTrue($response->isSuccessful());
+        $this->assertSame('9905168056260241A', $response->getTransactionReference());
+        $this->assertNull($response->getMessage());
+    }
+
     public function testTokenFailure()
     {
         $httpResponse = $this->getMockHttpResponse('RestTokenFailure.txt');

--- a/tests/Mock/RestExecuteSuccess.txt
+++ b/tests/Mock/RestExecuteSuccess.txt
@@ -1,0 +1,12 @@
+HTTP/1.1 200 OK
+Server: Apache-Coyote/1.1
+PROXY_SERVER_INFO: host=slcsbjava2.slc.paypal.com;threadId=127
+Paypal-Debug-Id: 030d6a098c7c5
+SERVER_INFO: paymentsplatformserv:v1.payments.authorization&CalThreadId=15946&TopLevelTxnStartTime=14701ba0b41&Host=slcsbjm3.slc.paypal.com&pid=15797
+CORRELATION-ID: 030d6a098c7c5
+Content-Language: *
+Date: Fri, 04 Jul 2014 14:14:42 GMT
+Content-Type: application/json
+Content-Length: 1521
+
+{"id":"PAY-74H06781N0485433NKTID2HQ","create_time":"2015-02-03T03:14:38Z","update_time":"2015-02-03T03:22:14Z","state":"approved","intent":"sale","payer":{"payment_method":"paypal","payer_info":{"email":"del-cust@babel.com.au","first_name":"Del","last_name":"Customer","payer_id":"49W2XWC7JM4JA","shipping_address":{"line1":"1 Cheeseman Ave Brighton East","city":"Melbourne","state":"Victoria","postal_code":"3001","country_code":"AU","recipient_name":"Del Customer"}}},"transactions":[{"amount":{"total":"10.00","currency":"AUD","details":{"subtotal":"10.00","fee":"0.54"}},"description":"This is a test purchase transaction.","related_resources":[{"sale":{"id":"9905168056260241A","create_time":"2015-02-03T03:14:38Z","update_time":"2015-02-03T03:22:14Z","amount":{"total":"10.00","currency":"AUD"},"payment_mode":"INSTANT_TRANSFER","state":"completed","protection_eligibility":"ELIGIBLE","protection_eligibility_type":"ITEM_NOT_RECEIVED_ELIGIBLE,UNAUTHORIZED_PAYMENT_ELIGIBLE","parent_payment":"PAY-74H06781N0485433NKTID2HQ","links":[{"href":"https://api.sandbox.paypal.com/v1/payments/sale/9905168056260241A","rel":"self","method":"GET"},{"href":"https://api.sandbox.paypal.com/v1/payments/sale/9905168056260241A/refund","rel":"refund","method":"POST"},{"href":"https://api.sandbox.paypal.com/v1/payments/payment/PAY-74H06781N0485433NKTID2HQ","rel":"parent_payment","method":"GET"}]}}]}],"links":[{"href":"https://api.sandbox.paypal.com/v1/payments/payment/PAY-74H06781N0485433NKTID2HQ","rel":"self","method":"GET"}]}


### PR DESCRIPTION
This PR adds the capability to accept PayPal payments through the REST API. It should work for both Purchase requests adn Authorize requests. The main difference is that if there is no credit card ID or credit card object passed to the Purchase or Authorize request, the getData() function now assumes that the payment_method == paypal (rather than always assuming that the payment_method == credit_card).

When a PayPal payment is made, the returnUrl and cancelUrl parameters are required in the Authorize or Payment request.  These are callback URLs that the PayPal payment site will redirect the customer to once the transaction has been approved on the PayPal web site.  These URLs will be passed the necessary paymentId and PayerID values as GET parameters.