### PR TITLE
send all other amounts along for complete purchase

### DIFF
--- a/src/Message/ExpressCompleteAuthorizeRequest.php
+++ b/src/Message/ExpressCompleteAuthorizeRequest.php
@@ -20,6 +20,13 @@ class ExpressCompleteAuthorizeRequest extends AbstractRequest
         $data['PAYMENTREQUEST_0_DESC'] = $this->getDescription();
         $data['PAYMENTREQUEST_0_NOTIFYURL'] = $this->getNotifyUrl();
 
+        $data['MAXAMT'] = $this->getMaxAmount();
+        $data['PAYMENTREQUEST_0_TAXAMT'] = $this->getTaxAmount();
+        $data['PAYMENTREQUEST_0_SHIPPINGAMT'] = $this->getShippingAmount();
+        $data['PAYMENTREQUEST_0_HANDLINGAMT'] = $this->getHandlingAmount();
+        $data['PAYMENTREQUEST_0_SHIPDISCAMT'] = $this->getShippingDiscount();
+        $data['PAYMENTREQUEST_0_INSURANCEAMT'] = $this->getInsuranceAmount();
+
         $data['TOKEN'] = $this->getToken() ? $this->getToken() : $this->httpRequest->query->get('token');
         $data['PAYERID'] = $this->getPayerID() ? $this->getPayerID() : $this->httpRequest->query->get('PayerID');
 

--- a/tests/Message/ExpressCompleteAuthorizeRequestTest.php
+++ b/tests/Message/ExpressCompleteAuthorizeRequestTest.php
@@ -34,6 +34,12 @@ class ExpressCompleteAuthorizeRequestTest extends TestCase
         $this->request->setSubject('SUB');
         $this->request->setDescription('DESC');
         $this->request->setNotifyUrl('https://www.example.com/notify');
+        $this->request->setMaxAmount('0.00');
+        $this->request->setTaxAmount('0.00');
+        $this->request->setShippingAmount('0.00');
+        $this->request->setHandlingAmount('0.00');
+        $this->request->setShippingDiscount('0.00');
+        $this->request->setInsuranceAmount('0.00');
 
         $expected = array();
         $expected['METHOD'] = 'DoExpressCheckoutPayment';
@@ -50,6 +56,12 @@ class ExpressCompleteAuthorizeRequestTest extends TestCase
         $expected['VERSION'] = ExpressCompleteAuthorizeRequest::API_VERSION;
         $expected['TOKEN'] = 'TOKEN1234';
         $expected['PAYERID'] = 'Payer-1234';
+        $expected['MAXAMT'] = '0.00';
+        $expected['PAYMENTREQUEST_0_TAXAMT'] = '0.00';
+        $expected['PAYMENTREQUEST_0_SHIPPINGAMT'] = '0.00';
+        $expected['PAYMENTREQUEST_0_HANDLINGAMT'] = '0.00';
+        $expected['PAYMENTREQUEST_0_SHIPDISCAMT'] = '0.00';
+        $expected['PAYMENTREQUEST_0_INSURANCEAMT'] = '0.00';
 
         $this->assertEquals($expected, $this->request->getData());
     }

--- a/tests/Message/ExpressCompletePurchaseRequestTest.php
+++ b/tests/Message/ExpressCompletePurchaseRequestTest.php
@@ -34,6 +34,12 @@ class ExpressCompletePurchaseRequestTest extends TestCase
         $this->request->setSubject('SUB');
         $this->request->setDescription('DESC');
         $this->request->setNotifyUrl('https://www.example.com/notify');
+        $this->request->setMaxAmount('0.00');
+        $this->request->setTaxAmount('0.00');
+        $this->request->setShippingAmount('0.00');
+        $this->request->setHandlingAmount('0.00');
+        $this->request->setShippingDiscount('0.00');
+        $this->request->setInsuranceAmount('0.00');
 
         $expected = array();
         $expected['METHOD'] = 'DoExpressCheckoutPayment';
@@ -50,6 +56,12 @@ class ExpressCompletePurchaseRequestTest extends TestCase
         $expected['VERSION'] = ExpressCompletePurchaseRequest::API_VERSION;
         $expected['TOKEN'] = 'TOKEN1234';
         $expected['PAYERID'] = 'Payer-1234';
+        $expected['MAXAMT'] = '0.00';
+        $expected['PAYMENTREQUEST_0_TAXAMT'] = '0.00';
+        $expected['PAYMENTREQUEST_0_SHIPPINGAMT'] = '0.00';
+        $expected['PAYMENTREQUEST_0_HANDLINGAMT'] = '0.00';
+        $expected['PAYMENTREQUEST_0_SHIPDISCAMT'] = '0.00';
+        $expected['PAYMENTREQUEST_0_INSURANCEAMT'] = '0.00';
 
         $this->assertEquals($expected, $this->request->getData());
     }


### PR DESCRIPTION
As described here https://github.com/thephpleague/omnipay-paypal/issues/45, if we send other amounts like shipping handling charges, discounts etc during authorization, that data needs to be set during complete purchase also. Otherwise we get error `Item total is not equal to order total`