### PR TITLE
Add support for passing BN Codes

### DIFF
--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -262,6 +262,19 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
         return $this->getParameter('sellerPaypalAccountId');
     }
 
+    /**
+     * The BN Code is for PayPal Partners taking payments for a 3rd party
+     */
+    public function setBNCode($value)
+    {
+        return $this->setParameter('BNCode', $value);
+    }
+
+    public function getBNCode()
+    {
+        return $this->getParameter('BNCode');
+    }
+
     protected function getBaseData()
     {
         $data = array();
@@ -270,7 +283,11 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
         $data['PWD'] = $this->getPassword();
         $data['SIGNATURE'] = $this->getSignature();
         $data['SUBJECT'] = $this->getSubject();
-
+        $bnCode = $this->getBNCode();
+        if (!empty($bnCode)) {
+            $data['BNCODE'] = $bnCode;
+        }
+        
         return $data;
     }
 

--- a/tests/Message/CaptureRequestTest.php
+++ b/tests/Message/CaptureRequestTest.php
@@ -28,6 +28,7 @@ class CaptureRequestTest extends TestCase
         $this->request->setPassword('testpass');
         $this->request->setSignature('SIG');
         $this->request->setSubject('SUB');
+        $this->request->setBNCode('BNCode_PP');
 
         $expected = array();
         $expected['METHOD'] = 'DoCapture';
@@ -39,6 +40,7 @@ class CaptureRequestTest extends TestCase
         $expected['PWD'] = 'testpass';
         $expected['SIGNATURE'] = 'SIG';
         $expected['SUBJECT'] = 'SUB';
+        $expected['BNCODE'] = 'BNCode_PP';
         $expected['VERSION'] = CaptureRequest::API_VERSION;
 
         $this->assertEquals($expected, $this->request->getData());


### PR DESCRIPTION
PayPal partner codes (BN Codes) are passed to PayPal Express Checkout by passing an additional parameter with the base data.

This adds simple accessors and adds to the base data unit tests to cover the new code.