### PR TITLE
Add RestPurchaseResponse

### DIFF
--- a/src/Message/RestPurchaseRequest.php
+++ b/src/Message/RestPurchaseRequest.php
@@ -72,7 +72,7 @@ namespace Omnipay\PayPal\Message;
  *
  * TODO: This class only works for direct credit card payments.  It should
  * be able to be made to work for PayPal payments too (by changing the
- * payer/payment_method parameter and adding linkback URLs). 
+ * payer/payment_method parameter and adding linkback URLs).
  *
  * @link https://developer.paypal.com/docs/api/#create-a-payment
  * @see RestAuthorizeRequest
@@ -84,5 +84,10 @@ class RestPurchaseRequest extends RestAuthorizeRequest
         $data = parent::getData();
         $data['intent'] = 'sale';
         return $data;
+    }
+
+    protected function createResponse($data, $statusCode)
+    {
+        return $this->response = new RestPurchaseResponse($this, $data, $statusCode);
     }
 }

--- a/src/Message/RestPurchaseResponse.php
+++ b/src/Message/RestPurchaseResponse.php
@@ -1,0 +1,10 @@
+<?php
+namespace Omnipay\PayPal\Message;
+
+class RestPurchaseResponse extends RestAuthorizeResponse
+{
+    public function isSuccessful()
+    {
+        return false;
+    }
+}

--- a/tests/RestGatewayTest.php
+++ b/tests/RestGatewayTest.php
@@ -76,7 +76,8 @@ class RestGatewayTest extends GatewayTestCase
 
         $response = $this->gateway->purchase($this->options)->send();
 
-        $this->assertTrue($response->isSuccessful());
+        $this->assertFalse($response->isSuccessful());
+        $this->assertTrue($response->isRedirect());
         $this->assertEquals('44E89981F8714392Y', $response->getTransactionReference());
         $this->assertNull($response->getMessage());
     }
@@ -108,7 +109,8 @@ class RestGatewayTest extends GatewayTestCase
 
         $this->setMockHttpResponse('RestPurchaseSuccess.txt');
         $response = $this->gateway->purchase(array('amount'=>'10.00', 'cardReference'=>$cardRef))->send();
-        $this->assertTrue($response->isSuccessful());
+        $this->assertFalse($response->isSuccessful());
+        $this->assertTrue($response->isRedirect());
         $this->assertEquals('44E89981F8714392Y', $response->getTransactionReference());
         $this->assertNull($response->getMessage());
     }


### PR DESCRIPTION
Don't know if this is a good idea or not, so let's use this PR as discussion material!

When you use the `purchase()` method, it will set `isSuccessful()` to `true` which kinda breaks the logic of Omnipay, since both `isSuccessful()` and `isRedirect()` will be true, the "default" logic of:
```
if ($response->isSuccessful()) {
...
} elseif ($response->isRedirect()) {
...
} else {
...
}
```
Won't work since it will never reach the `isRedirect()`

Thoughts?

EDIT: This seems to be a problem in multiple gateways (that they base `isSuccessful` in different things)
My guess is because the comment about the function is very open for interpretations
https://github.com/thephpleague/omnipay-common/blob/master/src/Omnipay/Common/Message/ResponseInterface.php#L30


EDIT2: I know the tests fails, I will fix those if the other changes gets an OK