### PR TITLE
Adding and fixing docblocks

### DIFF
--- a/src/Message/RestAuthorizeResponse.php
+++ b/src/Message/RestAuthorizeResponse.php
@@ -1,9 +1,15 @@
 <?php
-namespace Omnipay\PayPal\Message;
+/**
+ * PayPal REST Authorize Response
+ */
 
+namespace Omnipay\PayPal\Message;
 
 use Omnipay\Common\Message\RedirectResponseInterface;
 
+/**
+ * PayPal REST Authorize Response
+ */
 class RestAuthorizeResponse extends RestResponse implements RedirectResponseInterface
 {
     public function isSuccessful()
@@ -28,6 +34,8 @@ class RestAuthorizeResponse extends RestResponse implements RedirectResponseInte
 
     /**
      * Get the required redirect method (either GET or POST).
+     *
+     * @return string
      */
     public function getRedirectMethod()
     {
@@ -36,6 +44,8 @@ class RestAuthorizeResponse extends RestResponse implements RedirectResponseInte
 
     /**
      * Gets the redirect form data array, if the redirect method is POST.
+     *
+     * @return null
      */
     public function getRedirectData()
     {

--- a/src/Message/RestCompletePurchaseRequest.php
+++ b/src/Message/RestCompletePurchaseRequest.php
@@ -1,9 +1,38 @@
 <?php
-
+/**
+ * PayPal REST Complete Purchase Request
+ */
 
 namespace Omnipay\PayPal\Message;
 
-
+/**
+ * PayPal REST Complete Purchase Request
+ *
+ * Use this message to execute (complete) a PayPal payment that has been
+ * approved by the payer. You can optionally update transaction information
+ * when executing the payment by passing in one or more transactions.
+ *
+ * This call only works after a buyer has approved the payment using the
+ * provided PayPal approval URL.
+ *
+ * Example -- note this example assumes that the purchase has been successful
+ * and that the payer ID returned from the callback after the purchase is held
+ * in $payer_id, and that the transaction ID returned by the initial payment is
+ * held in $sale_id
+ * See RestPurchaseRequest for the first part of this example transaction:
+ *
+ * <code>
+ *   // Once the transaction has been approved, we need to complete it.
+ *   $transaction = $gateway->completePurchase(array(
+ *       'payer_id'             => $payer_id,
+ *       'transactionReference' => $sale_id,
+ *   ));
+ *   $response = $transaction->send();
+ * </code>
+ *
+ * @see RestPurchaseRequest
+ * @link https://developer.paypal.com/docs/api/#execute-an-approved-paypal-payment
+ */
 class RestCompletePurchaseRequest extends AbstractRestRequest
 {
     /**

--- a/src/Message/RestPurchaseRequest.php
+++ b/src/Message/RestPurchaseRequest.php
@@ -70,10 +70,6 @@ namespace Omnipay\PayPal\Message;
  * As of January 2015 these transactions are only supported in the UK
  * and in the USA.
  *
- * TODO: This class only works for direct credit card payments.  It should
- * be able to be made to work for PayPal payments too (by changing the
- * payer/payment_method parameter and adding linkback URLs). 
- *
  * @link https://developer.paypal.com/docs/api/#create-a-payment
  * @see RestAuthorizeRequest
  */


### PR DESCRIPTION
I have added docblocks to the newly added code for completing paypal payments.  I also removed a now-obsolete piece of documentation stating that the purchase request does not support paypal payments (which it now does).

There are no code changes contained in this PR, only documentation and comment changes.