### PR TITLE
Added formatCurrency to avoid API error message 'Item total is invalid.'

### DIFF
--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -305,6 +305,7 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
 
                 $data["PAYMENTREQUEST_0_ITEMAMT"] += $item->getQuantity() * $this->formatCurrency($item->getPrice());
             }
+            $data["PAYMENTREQUEST_0_ITEMAMT"] = $this->formatCurrency($data["PAYMENTREQUEST_0_ITEMAMT"]);
         }
 
         return $data;

--- a/tests/Message/ExpressAuthorizeRequestTest.php
+++ b/tests/Message/ExpressAuthorizeRequestTest.php
@@ -163,7 +163,7 @@ class ExpressAuthorizeRequestTest extends TestCase
         $this->assertSame(1, $data['L_PAYMENTREQUEST_0_QTY1']);
         $this->assertSame('40.00', $data['L_PAYMENTREQUEST_0_AMT1']);
 
-        $this->assertSame(floatval(60), $data['PAYMENTREQUEST_0_ITEMAMT']);
+        $this->assertSame('60.00', $data['PAYMENTREQUEST_0_ITEMAMT']);
     }
 
     public function testGetDataWithExtraOrderDetails()


### PR DESCRIPTION
Requests resultet mostly in errors like this because the request-parameter "PAYMENTREQUEST_0_ITEMAMT" was not correctly formatted to a string.

Response-Data:
```
{
    "TIMESTAMP": "2015-05-06T08:49:11Z",
    "CORRELATIONID": "...",
    "ACK": "Failure",
    "VERSION": "85.0",
    "BUILD": "16566018",
    "L_ERRORCODE0": "10426",
    "L_SHORTMESSAGE0": "Transaction refused because of an invalid argument. See additional error messages for details.",
    "L_LONGMESSAGE0": "Item total is invalid.",
    "L_SEVERITYCODE0": "Error"
  }
```

Request-Data:
```
{
    "VERSION": "85.0",
    "USER": "...",
    "PWD": "...",
    "SIGNATURE": "...",
    "SUBJECT": null,
    "METHOD": "SetExpressCheckout",
    "PAYMENTREQUEST_0_PAYMENTACTION": "Authorization",
    "PAYMENTREQUEST_0_AMT": "24.90",
    "PAYMENTREQUEST_0_CURRENCYCODE": "EUR",
    "PAYMENTREQUEST_0_INVNUM": null,
    "PAYMENTREQUEST_0_DESC": null,
    "SOLUTIONTYPE": "Sole",
    "LANDINGPAGE": "Login",
    "RETURNURL": "...",
    "CANCELURL": "...",
    "HDRIMG": "",
    "BRANDNAME": "",
    "NOSHIPPING": null,
    "ALLOWNOTE": null,
    "ADDROVERRIDE": null,
    "LOGOIMG": "",
    "CARTBORDERCOLOR": "",
    "LOCALECODE": null,
    "CUSTOMERSERVICENUMBER": null,
    "MAXAMT": null,
    "PAYMENTREQUEST_0_TAXAMT": null,
    "PAYMENTREQUEST_0_SHIPPINGAMT": 0,
    "PAYMENTREQUEST_0_HANDLINGAMT": null,
    "PAYMENTREQUEST_0_SHIPDISCAMT": null,
    "PAYMENTREQUEST_0_INSURANCEAMT": null,
    "PAYMENTREQUEST_0_SELLERPAYPALACCOUNTID": null,
    "PAYMENTREQUEST_0_ITEMAMT": 24.9,
    "L_PAYMENTREQUEST_0_NAME0": "...",
    "L_PAYMENTREQUEST_0_DESC0": null,
    "L_PAYMENTREQUEST_0_QTY0": "1",
    "L_PAYMENTREQUEST_0_AMT0": "24.90"
  }
```