### PR TITLE
Adding /cgi-bin/ to live and testCheckoutEndpoint path

### DIFF
--- a/src/Message/ExpressAuthorizeResponse.php
+++ b/src/Message/ExpressAuthorizeResponse.php
@@ -9,8 +9,8 @@ use Omnipay\Common\Message\RedirectResponseInterface;
  */
 class ExpressAuthorizeResponse extends Response implements RedirectResponseInterface
 {
-    protected $liveCheckoutEndpoint = 'https://www.paypal.com/webscr';
-    protected $testCheckoutEndpoint = 'https://www.sandbox.paypal.com/webscr';
+    protected $liveCheckoutEndpoint = 'https://www.paypal.com/cgi-bin/webscr';
+    protected $testCheckoutEndpoint = 'https://www.sandbox.paypal.com/cgi-bin/webscr';
 
     public function isSuccessful()
     {

--- a/tests/ExpressGatewayTest.php
+++ b/tests/ExpressGatewayTest.php
@@ -38,7 +38,7 @@ class ExpressGatewayTest extends GatewayTestCase
         $this->assertInstanceOf('\Omnipay\PayPal\Message\ExpressAuthorizeResponse', $response);
         $this->assertFalse($response->isSuccessful());
         $this->assertTrue($response->isRedirect());
-        $this->assertEquals('https://www.paypal.com/webscr?cmd=_express-checkout&useraction=commit&token=EC-42721413K79637829', $response->getRedirectUrl());
+        $this->assertEquals('https://www.paypal.com/cgi-bin/webscr?cmd=_express-checkout&useraction=commit&token=EC-42721413K79637829', $response->getRedirectUrl());
     }
 
     public function testAuthorizeFailure()
@@ -62,7 +62,7 @@ class ExpressGatewayTest extends GatewayTestCase
         $this->assertInstanceOf('\Omnipay\PayPal\Message\ExpressAuthorizeResponse', $response);
         $this->assertFalse($response->isSuccessful());
         $this->assertTrue($response->isRedirect());
-        $this->assertEquals('https://www.paypal.com/webscr?cmd=_express-checkout&useraction=commit&token=EC-42721413K79637829', $response->getRedirectUrl());
+        $this->assertEquals('https://www.paypal.com/cgi-bin/webscr?cmd=_express-checkout&useraction=commit&token=EC-42721413K79637829', $response->getRedirectUrl());
     }
 
     public function testPurchaseFailure()

--- a/tests/Message/ExpressAuthorizeResponseTest.php
+++ b/tests/Message/ExpressAuthorizeResponseTest.php
@@ -25,7 +25,7 @@ class ExpressAuthorizeResponseTest extends TestCase
         $this->assertSame('EC-42721413K79637829', $response->getTransactionReference());
         $this->assertNull($response->getMessage());
         $this->assertNull($response->getRedirectData());
-        $this->assertSame('https://www.sandbox.paypal.com/webscr?cmd=_express-checkout&useraction=commit&token=EC-42721413K79637829', $response->getRedirectUrl());
+        $this->assertSame('https://www.sandbox.paypal.com/cgi-bin/webscr?cmd=_express-checkout&useraction=commit&token=EC-42721413K79637829', $response->getRedirectUrl());
         $this->assertSame('GET', $response->getRedirectMethod());
     }
 


### PR DESCRIPTION
...for the ExpressAuthorizeResponse class.

See the [documentation](https://developer.paypal.com/docs/classic/express-checkout/integration-guide/ECGettingStarted/).

![screen shot 2015-06-02 at 2 08 52 pm](https://cloud.githubusercontent.com/assets/3967712/7947279/023a1aec-0931-11e5-9dd5-b18e85738170.png)

