### PR TITLE
Implement void

### DIFF
--- a/src/ExpressGateway.php
+++ b/src/ExpressGateway.php
@@ -138,6 +138,11 @@ class ExpressGateway extends ProGateway
         return $this->createRequest('\Omnipay\PayPal\Message\ExpressCompletePurchaseRequest', $parameters);
     }
 
+    public function void(array $parameters = array())
+    {
+        return $this->createRequest('\Omnipay\PayPal\Message\ExpressVoidRequest', $parameters);
+    }
+
     public function fetchCheckout(array $parameters = array())
     {
         return $this->createRequest('\Omnipay\PayPal\Message\ExpressFetchCheckoutRequest', $parameters);

--- a/src/Message/ExpressVoidRequest.php
+++ b/src/Message/ExpressVoidRequest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Omnipay\PayPal\Message;
+
+/**
+ * PayPal Express Void Request
+ */
+class ExpressVoidRequest extends AbstractRequest
+{
+    public function getData()
+    {
+        $this->validate('transactionReference');
+        $data = $this->getBaseData();
+        $data['METHOD'] = 'DoVoid';
+        $data['AUTHORIZATIONID'] = $this->getTransactionReference();
+        return $data;
+    }
+}

--- a/src/Message/Response.php
+++ b/src/Message/Response.php
@@ -23,7 +23,7 @@ class Response extends AbstractResponse
 
     public function getTransactionReference()
     {
-        foreach (array('REFUNDTRANSACTIONID', 'TRANSACTIONID', 'PAYMENTINFO_0_TRANSACTIONID') as $key) {
+        foreach (array('REFUNDTRANSACTIONID', 'TRANSACTIONID', 'PAYMENTINFO_0_TRANSACTIONID', 'AUTHORIZATIONID') as $key) {
             if (isset($this->data[$key])) {
                 return $this->data[$key];
             }

--- a/src/Message/Response.php
+++ b/src/Message/Response.php
@@ -23,7 +23,10 @@ class Response extends AbstractResponse
 
     public function getTransactionReference()
     {
-        foreach (array('REFUNDTRANSACTIONID', 'TRANSACTIONID', 'PAYMENTINFO_0_TRANSACTIONID', 'AUTHORIZATIONID') as $key) {
+        foreach (array('REFUNDTRANSACTIONID',
+            'TRANSACTIONID',
+            'PAYMENTINFO_0_TRANSACTIONID',
+            'AUTHORIZATIONID') as $key) {
             if (isset($this->data[$key])) {
                 return $this->data[$key];
             }

--- a/tests/ExpressGatewayTest.php
+++ b/tests/ExpressGatewayTest.php
@@ -16,6 +16,11 @@ class ExpressGatewayTest extends GatewayTestCase
      */
     protected $options;
 
+    /**
+     * @var array
+     */
+    protected $voidOptions;
+
     public function setUp()
     {
         parent::setUp();
@@ -26,6 +31,9 @@ class ExpressGatewayTest extends GatewayTestCase
             'amount' => '10.00',
             'returnUrl' => 'https://www.example.com/return',
             'cancelUrl' => 'https://www.example.com/cancel',
+        );
+        $this->voidOptions = array(
+            'transactionReference' => 'ASDFASDFASDF',
         );
     }
 
@@ -75,6 +83,28 @@ class ExpressGatewayTest extends GatewayTestCase
         $this->assertFalse($response->isRedirect());
         $this->assertNull($response->getTransactionReference());
         $this->assertSame('This transaction cannot be processed. The amount to be charged is zero.', $response->getMessage());
+    }
+
+    public function testVoidSuccess()
+    {
+        $this->setMockHttpResponse('ExpressVoidSuccess.txt');
+
+        $response = $this->gateway->void($this->voidOptions)->send();
+
+        $this->assertInstanceOf('\Omnipay\PayPal\Message\Response', $response);
+        $this->assertTrue($response->isSuccessful());
+        $this->assertFalse($response->isRedirect());
+        $this->assertEquals('ASDFASDFASDF', $response->getTransactionReference());
+    }
+
+    public function testVoidFailure()
+    {
+        $this->setMockHttpResponse('ExpressVoidFailure.txt');
+
+        $response = $this->gateway->void($this->voidOptions)->send();
+
+        $this->assertInstanceOf('\Omnipay\PayPal\Message\Response', $response);
+        $this->assertFalse($response->isSuccessful());
     }
 
     public function testFetchCheckout()

--- a/tests/Message/ExpressVoidRequestTest.php
+++ b/tests/Message/ExpressVoidRequestTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Omnipay\PayPal\Message;
+
+use Omnipay\Common\CreditCard;
+use Omnipay\Tests\TestCase;
+
+class ExpressVoidRequestTest extends TestCase
+{
+    /**
+     * @var ExpressVoidRequest
+     */
+    private $request;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->request = new ExpressVoidRequest($this->getHttpClient(), $this->getHttpRequest());
+        $this->request->initialize(
+            array(
+                'transactionReference' => 'ASDFASDFASDF',
+            )
+        );
+    }
+
+    public function testGetData()
+    {
+        $data = $this->request->getData();
+
+        $this->assertSame('ASDFASDFASDF', $data['AUTHORIZATIONID']);
+        $this->assertSame('DoVoid', $data['METHOD']);
+    }
+}

--- a/tests/Mock/ExpressVoidFailure.txt
+++ b/tests/Mock/ExpressVoidFailure.txt
@@ -1,0 +1,8 @@
+HTTP/1.1 200 OK
+Date: Fri, 15 Feb 2013 19:19:21 GMT
+Server: Apache
+Content-Length: 136
+Connection: close
+Content-Type: text/plain; charset=utf-8
+
+AUTHORIZATIONID=ASDFASDFASDF&TIMESTAMP=2013%2d02%2d15T19%3a19%3a21Z&CORRELATIONID=37b8b9915987c&ACK=Failure&VERSION=85%2e0&BUILD=5060305

--- a/tests/Mock/ExpressVoidSuccess.txt
+++ b/tests/Mock/ExpressVoidSuccess.txt
@@ -1,0 +1,8 @@
+HTTP/1.1 200 OK
+Date: Fri, 15 Feb 2013 19:19:21 GMT
+Server: Apache
+Content-Length: 136
+Connection: close
+Content-Type: text/plain; charset=utf-8
+
+AUTHORIZATIONID=ASDFASDFASDF&TIMESTAMP=2013%2d02%2d15T19%3a19%3a21Z&CORRELATIONID=37b8b9915987c&ACK=Success&VERSION=85%2e0&BUILD=5060305


### PR DESCRIPTION
This re-implements the addition of void to PayPal Express as first created by @alexw23 on PR #58 . I had originally intended to implement a void message in PayPal REST but I had mis-read the PayPal REST documentation, and voiding payments that have already been captured is not possible with REST.

This also fixes the formatting issues and adds test cases and mocks for void.

A PR to add documentation to the PayPal Express gateway and message code will follow some time later.
