### PR TITLE
Implement payment queries

### DIFF
--- a/src/Message/AbstractRestRequest.php
+++ b/src/Message/AbstractRestRequest.php
@@ -135,7 +135,7 @@ abstract class AbstractRestRequest extends \Omnipay\Common\Message\AbstractReque
         if ($this->getHttpMethod() == 'GET') {
             $httpRequest = $this->httpClient->createRequest(
                 $this->getHttpMethod(),
-                $this->getEndpoint(),
+                $this->getEndpoint() . '?' . http_build_query($data),
                 array(
                     'Accept' => 'application/json',
                     'Authorization' => 'Bearer ' . $this->getToken(),

--- a/src/Message/RestFetchPurchaseRequest.php
+++ b/src/Message/RestFetchPurchaseRequest.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * PayPal REST Fetch Purchase Request
+ */
+
+namespace Omnipay\PayPal\Message;
+
+/**
+ * PayPal REST Fetch Purchase Request
+ *
+ * Use this call to get details about payments that have not completed, such
+ * as payments that are created and approved, or if a payment has failed.
+ *
+ * ### Example
+ *
+ * See RestPurchaseRequest for the first part of this example transaction:
+ *
+ * <code>
+ *   // Fetch the transaction so that details can be found for refund, etc.
+ *   $transaction = $gateway->fetchPurchase();
+ *   $transaction->setTransactionReference($sale_id);
+ *   $response = $transaction->send();
+ *   $data = $response->getData();
+ *   echo "Gateway fetchTransaction response data == " . print_r($data, true) . "\n";
+ * </code>
+ *
+ * @see RestPurchaseRequest
+ * @link https://developer.paypal.com/docs/api/#look-up-a-payment-resource
+ */
+class RestFetchPurchaseRequest extends AbstractRestRequest
+{
+    public function getData()
+    {
+        $this->validate('transactionReference');
+        return array();
+    }
+
+    /**
+     * Get HTTP Method.
+     *
+     * The HTTP method for fetchTransaction requests must be GET.
+     * Using POST results in an error 500 from PayPal.
+     *
+     * @return string
+     */
+    protected function getHttpMethod()
+    {
+        return 'GET';
+    }
+
+    public function getEndpoint()
+    {
+        return parent::getEndpoint() . '/payments/payment/' . $this->getTransactionReference();
+    }
+}

--- a/src/Message/RestListPurchaseRequest.php
+++ b/src/Message/RestListPurchaseRequest.php
@@ -1,0 +1,164 @@
+<?php
+/**
+ * PayPal REST List Purchase Request
+ */
+
+namespace Omnipay\PayPal\Message;
+
+/**
+ * PayPal REST List Purchase Request
+ *
+ * Use this call to get a list of payments in any state (created, approved,
+ * failed, etc.). The payments returned are the payments made to the merchant
+ * making the call.
+ *
+ * ### Example
+ *
+ * See RestPurchaseRequest for the first part of this example transaction:
+ *
+ * <code>
+ *   // List the transaction so that details can be found for refund, etc.
+ *   $transaction = $gateway->listPurchase();
+ *   $response = $transaction->send();
+ *   $data = $response->getData();
+ *   echo "Gateway listPurchase response data == " . print_r($data, true) . "\n";
+ * </code>
+ *
+ * @see RestPurchaseRequest
+ * @link https://developer.paypal.com/docs/api/#list-payment-resources
+ */
+class RestListPurchaseRequest extends AbstractRestRequest
+{
+    /**
+     * Get the request count
+     *
+     * @return integer
+     */
+    public function getCount()
+    {
+        return $this->getParameter('count');
+    }
+
+    /**
+     * Set the request count
+     *
+     * @param integer $value
+     * @return AbstractRestRequest provides a fluent interface.
+     */
+    public function setCount($value)
+    {
+        return $this->setParameter('count', $value);
+    }
+
+    /**
+     * Get the request startId
+     *
+     * @return string
+     */
+    public function getStartId()
+    {
+        return $this->getParameter('startId');
+    }
+
+    /**
+     * Set the request startId
+     *
+     * @param string $value
+     * @return AbstractRestRequest provides a fluent interface.
+     */
+    public function setStartId($value)
+    {
+        return $this->setParameter('startId', $value);
+    }
+
+    /**
+     * Get the request startIndex
+     *
+     * @return integer
+     */
+    public function getStartIndex()
+    {
+        return $this->getParameter('startIndex');
+    }
+
+    /**
+     * Set the request startIndex
+     *
+     * @param integer $value
+     * @return AbstractRestRequest provides a fluent interface.
+     */
+    public function setStartIndex($value)
+    {
+        return $this->setParameter('startIndex', $value);
+    }
+
+    /**
+     * Get the request startTime
+     *
+     * @return string
+     */
+    public function getStartTime()
+    {
+        return $this->getParameter('startTime');
+    }
+
+    /**
+     * Set the request startTime
+     *
+     * @param string $value
+     * @return AbstractRestRequest provides a fluent interface.
+     */
+    public function setStartTime($value)
+    {
+        return $this->setParameter('startTime', $value);
+    }
+
+    /**
+     * Get the request endTime
+     *
+     * @return string
+     */
+    public function getEndTime()
+    {
+        return $this->getParameter('endTime');
+    }
+
+    /**
+     * Set the request endTime
+     *
+     * @param string $value
+     * @return AbstractRestRequest provides a fluent interface.
+     */
+    public function setEndTime($value)
+    {
+        return $this->setParameter('endTime', $value);
+    }
+
+    public function getData()
+    {
+        return array(
+            'count'             => $this->getCount(),
+            'start_id'          => $this->getStartId(),
+            'start_index'       => $this->getStartIndex(),
+            'start_time'        => $this->getStartTime(),
+            'end_time'          => $this->getEndTime(),
+        );
+    }
+
+    /**
+     * Get HTTP Method.
+     *
+     * The HTTP method for listPurchase requests must be GET.
+     *
+     * @return string
+     */
+    protected function getHttpMethod()
+    {
+        return 'GET';
+    }
+
+    public function getEndpoint()
+    {
+        return parent::getEndpoint() . '/payments/payment';
+    }
+}

--- a/src/Message/RestListPurchaseRequest.php
+++ b/src/Message/RestListPurchaseRequest.php
@@ -217,7 +217,8 @@ class RestListPurchaseRequest extends AbstractRestRequest
     public function setStartTime($value)
     {
         if ($value instanceof \DateTime) {
-            $value = $value->format(\DateTime::RFC3339);
+            $value->setTimezone(new \DateTimeZone('UTC'));
+            $value = $value->format('Y-m-d\TH:i:s\Z');
         }
         return $this->setParameter('startTime', $value);
     }
@@ -235,11 +236,15 @@ class RestListPurchaseRequest extends AbstractRestRequest
     /**
      * Set the request endTime
      *
-     * @param string $value
+     * @param string|\DateTime $value
      * @return AbstractRestRequest provides a fluent interface.
      */
     public function setEndTime($value)
     {
+        if ($value instanceof \DateTime) {
+            $value->setTimezone(new \DateTimeZone('UTC'));
+            $value = $value->format('Y-m-d\TH:i:s\Z');
+        }
         return $this->setParameter('endTime', $value);
     }
 

--- a/src/Message/RestListPurchaseRequest.php
+++ b/src/Message/RestListPurchaseRequest.php
@@ -17,11 +17,117 @@ namespace Omnipay\PayPal\Message;
  * See RestPurchaseRequest for the first part of this example transaction:
  *
  * <code>
+ *   // Make some DateTimes for start and end times
+ *   $start_time = new \DateTime('yesterday');
+ *   $end_time = new \DateTime('now');
+ *
  *   // List the transaction so that details can be found for refund, etc.
- *   $transaction = $gateway->listPurchase();
+ *   $transaction = $gateway->listPurchase(
+ *       'startTime' => $start_time,
+ *       'endTime    => $end_time
+ *   );
  *   $response = $transaction->send();
  *   $data = $response->getData();
  *   echo "Gateway listPurchase response data == " . print_r($data, true) . "\n";
+ * </code>
+ *
+ * ### Request Sample
+ *
+ * This is from the PayPal web site:
+ *
+ * <code>
+ * curl -v -X GET https://api.sandbox.paypal.com/v1/payments/payment?
+ *     sort_order=asc&sort_by=update_time \
+ *     -H "Content-Type:application/json" \
+ *     -H "Authorization: Bearer <Access-Token>"
+ * </code>
+ *
+ * ### Response Sample
+ *
+ * This is from the PayPal web site:
+ *
+ * <code>
+ * {
+ *     "payments": [
+ *         {
+ *             "id": "PAY-4D099447DD202993VKEFMRJQ",
+ *             "create_time": "2013-01-31T19:40:22Z",
+ *             "update_time": "2013-01-31T19:40:24Z",
+ *             "state": "approved",
+ *             "intent": "sale",
+ *             "payer": {
+ *                 "payment_method": "credit_card",
+ *                 "funding_instruments": [
+ *                     {
+ *                         "credit_card": {
+ *                             "type": "visa",
+ *                             "number": "xxxxxxxxxxxx0331",
+ *                             "expire_month": "10",
+ *                             "expire_year": "2018",
+ *                             "first_name": "Betsy",
+ *                             "last_name": "Buyer",
+ *                             "billing_address": {
+ *                                 "line1": "111 First Street",
+ *                                 "city": "Saratoga",
+ *                                 "state": "CA",
+ *                                 "postal_code": "95070",
+ *                                 "country_code": "US"
+ *                             }
+ *                         }
+ *                     }
+ *                 ]
+ *             },
+ *             "transactions": [
+ *                 {
+ *                     "amount": {
+ *                         "total": "110.54",
+ *                         "currency": "USD"
+ *                     },
+ *                     "description": "This is the payment transaction description.",
+ *                     "related_resources": [
+ *                         {
+ *                             "sale": {
+ *                                 "id": "1D971400A7097562W",
+ *                                 "create_time": "2013-01-31T19:40:23Z",
+ *                                 "update_time": "2013-01-31T19:40:25Z",
+ *                                 "state": "completed",
+ *                                 "amount": {
+ *                                     "total": "110.54",
+ *                                     "currency": "USD"
+ *                                 },
+ *                                 "parent_payment": "PAY-4D099447DD202993VKEFMRJQ",
+ *                                 "links": [
+ *                                     {
+ *                                         "href": "https://api.sandbox.paypal.com/v1/payments/sale/1D971400A7097562W",
+ *                                         "rel": "self",
+ *                                         "method": "GET"
+ *                                     },
+ *                                     {
+ *                                         "href": "https://api.sandbox.paypal.com/v1/payments/sale/1D971400A7097562W/refund",
+ *                                         "rel": "refund",
+ *                                         "method": "POST"
+ *                                     },
+ *                                     {
+ *                                         "href": "https://api.sandbox.paypal.com/v1/payments/payment/PAY-4D099447DD202993VKEFMRJQ",
+ *                                         "rel": "parent_payment",
+ *                                         "method": "GET"
+ *                                     }
+ *                                 ]
+ *                             }
+ *                         }
+ *                     ]
+ *                 }
+ *             ],
+ *             "links": [
+ *                          {
+ *                              "href": "https://api.sandbox.paypal.com/v1/payments/payment/PAY-4D099447DD202993VKEFMRJQ",
+ *                              "rel": "self",
+ *                              "method": "GET"
+ *                          }
+ *                      ]
+ *         }
+ *     ]
+ * }
  * </code>
  *
  * @see RestPurchaseRequest
@@ -105,11 +211,14 @@ class RestListPurchaseRequest extends AbstractRestRequest
     /**
      * Set the request startTime
      *
-     * @param string $value
+     * @param string|\DateTime $value
      * @return AbstractRestRequest provides a fluent interface.
      */
     public function setStartTime($value)
     {
+        if ($value instanceof \DateTime) {
+            $value = $value->format(\DateTime::RFC3339);
+        }
         return $this->setParameter('startTime', $value);
     }
 

--- a/src/Message/RestListPurchaseRequest.php
+++ b/src/Message/RestListPurchaseRequest.php
@@ -98,17 +98,20 @@ namespace Omnipay\PayPal\Message;
  *                                 "parent_payment": "PAY-4D099447DD202993VKEFMRJQ",
  *                                 "links": [
  *                                     {
- *                                         "href": "https://api.sandbox.paypal.com/v1/payments/sale/1D971400A7097562W",
+ *                                         "href":
+ * "https://api.sandbox.paypal.com/v1/payments/sale/1D971400A7097562W",
  *                                         "rel": "self",
  *                                         "method": "GET"
  *                                     },
  *                                     {
- *                                         "href": "https://api.sandbox.paypal.com/v1/payments/sale/1D971400A7097562W/refund",
+ *                                         "href":
+ * "https://api.sandbox.paypal.com/v1/payments/sale/1D971400A7097562W/refund",
  *                                         "rel": "refund",
  *                                         "method": "POST"
  *                                     },
  *                                     {
- *                                         "href": "https://api.sandbox.paypal.com/v1/payments/payment/PAY-4D099447DD202993VKEFMRJQ",
+ *                                         "href":
+ * "https://api.sandbox.paypal.com/v1/payments/payment/PAY-4D099447DD202993VKEFMRJQ",
  *                                         "rel": "parent_payment",
  *                                         "method": "GET"
  *                                     }
@@ -120,7 +123,8 @@ namespace Omnipay\PayPal\Message;
  *             ],
  *             "links": [
  *                          {
- *                              "href": "https://api.sandbox.paypal.com/v1/payments/payment/PAY-4D099447DD202993VKEFMRJQ",
+ *                              "href":
+ * "https://api.sandbox.paypal.com/v1/payments/payment/PAY-4D099447DD202993VKEFMRJQ",
  *                              "rel": "self",
  *                              "method": "GET"
  *                          }

--- a/src/RestGateway.php
+++ b/src/RestGateway.php
@@ -369,6 +369,22 @@ class RestGateway extends AbstractGateway
     }
 
     /**
+     * List purchase requests.
+     *
+     * Use this call to get a list of payments in any state (created, approved,
+     * failed, etc.). The payments returned are the payments made to the merchant
+     * making the call.
+     *
+     * @link https://developer.paypal.com/docs/api/#list-payment-resources
+     * @param array $parameters
+     * @return \Omnipay\PayPal\Message\RestListPurchaseRequest
+     */
+    public function listPurchase(array $parameters = array())
+    {
+        return $this->createRequest('\Omnipay\PayPal\Message\RestListPurchaseRequest', $parameters);
+    }
+
+    /**
      * Completes a purchase request.
      *
      * @link https://developer.paypal.com/docs/api/#execute-an-approved-paypal-payment

--- a/src/RestGateway.php
+++ b/src/RestGateway.php
@@ -396,9 +396,7 @@ class RestGateway extends AbstractGateway
         return $this->createRequest('\Omnipay\PayPal\Message\RestCompletePurchaseRequest', $parameters);
     }
 
-    // TODO: Look up a payment resource https://developer.paypal.com/docs/api/#look-up-a-payment-resource
     // TODO: Update a payment resource https://developer.paypal.com/docs/api/#update-a-payment-resource
-    // TODO: List payment resources https://developer.paypal.com/docs/api/#list-payment-resources
 
     //
     // Authorizations -- Capture, reauthorize, void and look up authorizations.

--- a/src/RestGateway.php
+++ b/src/RestGateway.php
@@ -354,6 +354,21 @@ class RestGateway extends AbstractGateway
     }
 
     /**
+     * Fetch a purchase request.
+     *
+     * Use this call to get details about payments that have not completed,
+     * such as payments that are created and approved, or if a payment has failed.
+     *
+     * @link https://developer.paypal.com/docs/api/#look-up-a-payment-resource
+     * @param array $parameters
+     * @return \Omnipay\PayPal\Message\RestFetchPurchaseRequest
+     */
+    public function fetchPurchase(array $parameters = array())
+    {
+        return $this->createRequest('\Omnipay\PayPal\Message\RestFetchPurchaseRequest', $parameters);
+    }
+
+    /**
      * Completes a purchase request.
      *
      * @link https://developer.paypal.com/docs/api/#execute-an-approved-paypal-payment

--- a/tests/Message/RestFetchPurchaseRequestTest.php
+++ b/tests/Message/RestFetchPurchaseRequestTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Omnipay\PayPal\Message;
+
+use Omnipay\Tests\TestCase;
+
+class RestFetchPurchaseRequestTest extends TestCase
+{
+    /** @var \Omnipay\PayPal\Message\RestFetchPurchaseRequest */
+    private $request;
+
+    public function setUp()
+    {
+        $client = $this->getHttpClient();
+        $request = $this->getHttpRequest();
+        $this->request = new RestFetchPurchaseRequest($client, $request);
+    }
+
+    public function testEndpoint()
+    {
+        $this->request->setTransactionReference('ABC-123');
+        $this->assertStringEndsWith('/payments/payment/ABC-123', $this->request->getEndpoint());
+    }
+}

--- a/tests/Mock/RestFetchPurchaseSuccess.txt
+++ b/tests/Mock/RestFetchPurchaseSuccess.txt
@@ -1,0 +1,53 @@
+HTTP/1.1 201 Created
+Server: Apache-Coyote/1.1
+PROXY_SERVER_INFO: host=slcsbjava2.slc.paypal.com;threadId=1534
+Paypal-Debug-Id: 98cbd3ab19dfe
+SERVER_INFO: paymentsplatformserv:v1.payments.payment&CalThreadId=129&TopLevelTxnStartTime=146fc9074ec&Host=slcsbjm3.slc.paypal.com&pid=15797
+CORRELATION-ID: 98cbd3ab19dfe
+Content-Language: *
+Date: Thu, 03 Jul 2014 14:11:10 GMT
+Content-Type: application/json
+
+{
+    "id": "PAY-0WB587530N302915SKXWVCSQ",
+    "create_time": "2015-09-07T08:56:42Z",
+    "update_time": "2015-09-07T08:56:42Z",
+    "state": "created",
+    "intent": "sale",
+    "payer": {
+        "payment_method": "paypal",
+        "payer_info": {
+            "shipping_address": []
+        }
+    },
+    "transactions": [
+        {
+            "amount": {
+                "total": "10.00",
+                "currency": "AUD",
+                "details": {
+                    "subtotal": "10.00"
+                }
+            },
+            "description": "This is a test purchase transaction.",
+            "related_resources": []
+        }
+    ],
+    "links": [
+        {
+            "href": "https:\/\/api.sandbox.paypal.com\/v1\/payments\/payment\/PAY-0WB587530N302915SKXWVCSQ",
+            "rel": "self",
+            "method": "GET"
+        },
+        {
+            "href": "https:\/\/www.sandbox.paypal.com\/cgi-bin\/webscr?cmd=_express-checkout&token=EC-3DR71034MD528800J",
+            "rel": "approval_url",
+            "method": "REDIRECT"
+        },
+        {
+            "href": "https:\/\/api.sandbox.paypal.com\/v1\/payments\/payment\/PAY-0WB587530N302915SKXWVCSQ\/execute",
+            "rel": "execute",
+            "method": "POST"
+        }
+    ]
+}

--- a/tests/RestGatewayTest.php
+++ b/tests/RestGatewayTest.php
@@ -147,6 +147,28 @@ class RestGatewayTest extends GatewayTestCase
         $this->assertEmpty($data);
     }
 
+    public function testListPurchase()
+    {
+        $request = $this->gateway->listPurchase(array(
+            'count'         => 15,
+            'startId'       => 'PAY123',
+            'startIndex'    => 1,
+            'startTime'     => '2015-09-07T00:00:00Z',
+            'endTime'       => '2015-09-08T00:00:00Z',
+        ));
+
+        $this->assertInstanceOf('\Omnipay\PayPal\Message\RestListPurchaseRequest', $request);
+        $this->assertSame(15, $request->getCount());
+        $this->assertSame('PAY123', $request->getStartId());
+        $this->assertSame(1, $request->getStartIndex());
+        $this->assertSame('2015-09-07T00:00:00Z', $request->getStartTime());
+        $this->assertSame('2015-09-08T00:00:00Z', $request->getEndTime());
+        $endPoint = $request->getEndpoint();
+        $this->assertSame('https://api.paypal.com/v1/payments/payment', $endPoint);
+        $data = $request->getData();
+        $this->assertNotEmpty($data);
+    }
+
     public function testCreateCard()
     {
         $this->setMockHttpResponse('RestCreateCardSuccess.txt');

--- a/tests/RestGatewayTest.php
+++ b/tests/RestGatewayTest.php
@@ -81,12 +81,70 @@ class RestGatewayTest extends GatewayTestCase
         $this->assertNull($response->getMessage());
     }
 
+    public function testCapture()
+    {
+        $request = $this->gateway->capture(array(
+            'transactionReference' => 'abc123',
+            'amount' => 10.00,
+            'currency' => 'AUD',
+        ));
+
+        $this->assertInstanceOf('\Omnipay\PayPal\Message\RestCaptureRequest', $request);
+        $this->assertSame('abc123', $request->getTransactionReference());
+        $endPoint = $request->getEndpoint();
+        $this->assertSame('https://api.paypal.com/v1/payments/authorization/abc123/capture', $endPoint);
+        $data = $request->getData();
+        $this->assertNotEmpty($data);
+    }
+
+    public function testRefund()
+    {
+        $request = $this->gateway->refund(array(
+            'transactionReference' => 'abc123',
+            'amount' => 10.00,
+            'currency' => 'AUD',
+        ));
+
+        $this->assertInstanceOf('\Omnipay\PayPal\Message\RestRefundRequest', $request);
+        $this->assertSame('abc123', $request->getTransactionReference());
+        $endPoint = $request->getEndpoint();
+        $this->assertSame('https://api.paypal.com/v1/payments/sale/abc123/refund', $endPoint);
+        $data = $request->getData();
+        $this->assertNotEmpty($data);
+    }
+
+    public function testFullRefund()
+    {
+        $request = $this->gateway->refund(array(
+            'transactionReference' => 'abc123',
+        ));
+
+        $this->assertInstanceOf('\Omnipay\PayPal\Message\RestRefundRequest', $request);
+        $this->assertSame('abc123', $request->getTransactionReference());
+        $endPoint = $request->getEndpoint();
+        $this->assertSame('https://api.paypal.com/v1/payments/sale/abc123/refund', $endPoint);
+        $data = $request->getData();
+        $this->assertEmpty($data);
+    }
+
     public function testFetchTransaction()
     {
         $request = $this->gateway->fetchTransaction(array('transactionReference' => 'abc123'));
 
         $this->assertInstanceOf('\Omnipay\PayPal\Message\RestFetchTransactionRequest', $request);
         $this->assertSame('abc123', $request->getTransactionReference());
+        $data = $request->getData();
+        $this->assertEmpty($data);
+    }
+
+    public function testFetchPurchase()
+    {
+        $request = $this->gateway->fetchPurchase(array('transactionReference' => 'abc123'));
+
+        $this->assertInstanceOf('\Omnipay\PayPal\Message\RestFetchPurchaseRequest', $request);
+        $this->assertSame('abc123', $request->getTransactionReference());
+        $data = $request->getData();
+        $this->assertEmpty($data);
     }
 
     public function testCreateCard()


### PR DESCRIPTION
This PR implements queries on the PayPal payment resources. 2 additional gateway methods are available: fetchPurchase and listPurchase. As opposed to fetchTransaction these operate on any type of transaction, not just completed transactions.

These methods are often the only way that an application can determine that PayPal has completed a purchase in the event of, for example, the customer's browser crashing or the customer closing their browser between the customer authorizing the payment at the PayPal gateway and returning via the returnUrl to the merchant's web site.