### PR TITLE
Implement recurring payments

### DIFF
--- a/src/Message/AbstractRestRequest.php
+++ b/src/Message/AbstractRestRequest.php
@@ -135,7 +135,7 @@ abstract class AbstractRestRequest extends \Omnipay\Common\Message\AbstractReque
         if ($this->getHttpMethod() == 'GET') {
             $httpRequest = $this->httpClient->createRequest(
                 $this->getHttpMethod(),
-                $this->getEndpoint(),
+                $this->getEndpoint() . '?' . http_build_query($data),
                 array(
                     'Accept' => 'application/json',
                     'Authorization' => 'Bearer ' . $this->getToken(),

--- a/src/Message/RestAuthorizeResponse.php
+++ b/src/Message/RestAuthorizeResponse.php
@@ -36,6 +36,49 @@ class RestAuthorizeResponse extends RestResponse implements RedirectResponseInte
     }
 
     /**
+     * Get the URL to complete (execute) the purchase or agreement.
+     *
+     * The URL is embedded in the links section of the purchase or create
+     * subscription request response.
+     *
+     * @return string
+     */
+    public function getCompleteUrl()
+    {
+        if (isset($this->data['links']) && is_array($this->data['links'])) {
+            foreach ($this->data['links'] as $key => $value) {
+                if ($value['rel'] == 'execute') {
+                    return $value['href'];
+                }
+            }
+        }
+
+        return null;
+    }
+
+    public function getTransactionReference()
+    {
+        // The transaction reference for a paypal purchase request or for a
+        // paypal create subscription request ends up in the execute URL
+        // in the links section of the response.
+        $completeUrl = $this->getCompleteUrl();
+        if (empty($completeUrl)) {
+            return parent::getTransactionReference();
+        }
+
+        $urlParts = explode('/', $completeUrl);
+
+        // The last element of the URL should be "execute"
+        $execute = end($urlParts);
+        if ($execute != 'execute') {
+            return parent::getTransactionReference();
+        }
+
+        // The penultimate element should be the transaction reference
+        return prev($urlParts);
+    }
+
+    /**
      * Get the required redirect method (either GET or POST).
      *
      * @return string

--- a/src/Message/RestAuthorizeResponse.php
+++ b/src/Message/RestAuthorizeResponse.php
@@ -24,12 +24,15 @@ class RestAuthorizeResponse extends RestResponse implements RedirectResponseInte
 
     public function getRedirectUrl()
     {
-        $redirectUrl = null;
-        if (isset($this->data['links'][1]) && $this->data['links'][1]['rel'] == 'approval_url') {
-            $redirectUrl = $this->data['links'][1]['href'];
+        if (isset($this->data['links']) && is_array($this->data['links'])) {
+            foreach ($this->data['links'] as $key => $value) {
+                if ($value['rel'] == 'approval_url') {
+                    return $value['href'];
+                }
+            }
         }
 
-        return $redirectUrl;
+        return null;
     }
 
     /**

--- a/src/Message/RestCancelSubscriptionRequest.php
+++ b/src/Message/RestCancelSubscriptionRequest.php
@@ -70,7 +70,7 @@ class RestCancelSubscriptionRequest extends AbstractRestRequest
 {
     public function getData()
     {
-        $this->validate('transactionReference');
+        $this->validate('transactionReference', 'description');
         $data = array(
             'note'  => $this->getDescription(),
         );

--- a/src/Message/RestCancelSubscriptionRequest.php
+++ b/src/Message/RestCancelSubscriptionRequest.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * PayPal REST Cancel Subscription Request
+ */
+
+namespace Omnipay\PayPal\Message;
+
+/**
+ * PayPal REST Cancel Subscription Request
+ *
+ * Use this call to cancel an agreement after the buyer approves it.
+ *
+ * ### Request Data
+ *
+ * Pass the agreement id in the URI of a POST call.  Also include a description,
+ * which is the reason for cancelling the subscription.
+ *
+ * ### Example
+ *
+ * To create the agreement, see the code example in RestCreateSubscriptionRequest.
+ *
+ * <code>
+ *   // Create a gateway for the PayPal REST Gateway
+ *   // (routes to GatewayFactory::create)
+ *   $gateway = Omnipay::create('Paypal_Rest');
+ *
+ *   // Initialise the gateway
+ *   $gateway->initialize(array(
+ *       'clientId' => 'MyPayPalClientId',
+ *       'secret'   => 'MyPayPalSecret',
+ *       'testMode' => true, // Or false when you are ready for live transactions
+ *   ));
+ *
+ *   // Do a complete subscription transaction on the gateway
+ *   $transaction = $gateway->cancelSubscription(array(
+ *       'transactionReference'     => $subscription_id,
+ *       'description'              => "Cancelling the agreement.",
+ *   ));
+ *   $response = $transaction->send();
+ *   if ($response->isSuccessful()) {
+ *       echo "Cancel Subscription transaction was successful!\n";
+ *   }
+ * </code>
+ *
+ * Note that the subscription_id that you get from calling the response's
+ * getTransactionReference() method at the end of the completeSubscription
+ * call will be different to the one that you got after calling the response's
+ * getTransactionReference() method at the end of the createSubscription
+ * call.  The one that you get from completeSubscription is the correct
+ * one to use going forwards (e.g. for cancelling or updating the subscription).
+ *
+ * ### Request Sample
+ *
+ * This is from the PayPal web site:
+ *
+ * <code>
+ * curl -v POST https://api.sandbox.paypal.com/v1/payments/billing-agreements/I-0LN988D3JACS/cancel \
+ *     -H 'Content-Type:application/json' \
+ *     -H 'Authorization: Bearer <Access-Token>' \
+ *     -d '{
+ *         "note": "Canceling the agreement."
+ *     }'
+ * </code>
+ *
+ * @link https://developer.paypal.com/docs/api/#cancel-an-agreement
+ * @see RestCreateSubscriptionRequest
+ * @see Omnipay\PayPal\RestGateway
+ */
+class RestCancelSubscriptionRequest extends AbstractRestRequest
+{
+    public function getData()
+    {
+        $this->validate('transactionReference');
+        $data = array(
+            'note'  => $this->getDescription(),
+        );
+
+        return $data;
+    }
+
+    /**
+     * Get transaction endpoint.
+     *
+     * Subscriptions are executed using the /billing-agreements resource.
+     *
+     * @return string
+     */
+    protected function getEndpoint()
+    {
+        return parent::getEndpoint() . '/payments/billing-agreements/' .
+            $this->getTransactionReference() . '/cancel';
+    }
+}

--- a/src/Message/RestCompleteSubscriptionRequest.php
+++ b/src/Message/RestCompleteSubscriptionRequest.php
@@ -116,9 +116,4 @@ class RestCompleteSubscriptionRequest extends AbstractRestRequest
     {
         return parent::getEndpoint() . '/payments/billing-agreements/' . $this->getTransactionReference() . '/execute';
     }
-
-    protected function createResponse($data, $statusCode)
-    {
-        return $this->response = new RestAuthorizeResponse($this, $data, $statusCode);
-    }
 }

--- a/src/Message/RestCompleteSubscriptionRequest.php
+++ b/src/Message/RestCompleteSubscriptionRequest.php
@@ -108,7 +108,7 @@ class RestCompleteSubscriptionRequest extends AbstractRestRequest
     /**
      * Get transaction endpoint.
      *
-     * Complete Subscriptions are created using the /purchases resource.
+     * Subscriptions are executed using the /billing-agreements resource.
      *
      * @return string
      */

--- a/src/Message/RestCompleteSubscriptionRequest.php
+++ b/src/Message/RestCompleteSubscriptionRequest.php
@@ -114,6 +114,7 @@ class RestCompleteSubscriptionRequest extends AbstractRestRequest
      */
     protected function getEndpoint()
     {
-        return parent::getEndpoint() . '/payments/billing-agreements/' . $this->getTransactionReference() . '/agreement-execute';
+        return parent::getEndpoint() . '/payments/billing-agreements/' .
+            $this->getTransactionReference() . '/agreement-execute';
     }
 }

--- a/src/Message/RestCompleteSubscriptionRequest.php
+++ b/src/Message/RestCompleteSubscriptionRequest.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * PayPal REST Complete Subscription Request
+ */
+
+namespace Omnipay\PayPal\Message;
+
+/**
+ * PayPal REST Complete Subscription Request
+ *
+ * Use this call to execute an agreement after the buyer approves it.
+ *
+ * Note: This request is only necessary for PayPal payments. Billing
+ * agreements for credit card payments execute automatically at the time
+ * of creation and so this request is not necessary for credit card payments.
+ *
+ * ### Request Data
+ *
+ * Pass the token in the URI of a POST call to execute the subscription
+ * agreement after buyer approval. You can find the token in the execute
+ * link returned by the request to create a billing agreement.
+ *
+ * No other data is required.
+ *
+ * ### Example
+ *
+ * To create the agreement, see the code example in RestCreateSubscriptionRequest.
+ *
+ * At the completion of a createSubscription call, the customer should be
+ * redirected to the redirect URL contained in $response->getRedirectUrl().  Once
+ * the customer has approved the agreement and be returned to the returnUrl
+ * in the call.  The returnUrl can contain the following code to complete
+ * the agreement:
+ *
+ * <code>
+ *   // Create a gateway for the PayPal REST Gateway
+ *   // (routes to GatewayFactory::create)
+ *   $gateway = Omnipay::create('Paypal_Rest');
+ *
+ *   // Initialise the gateway
+ *   $gateway->initialize(array(
+ *       'clientId' => 'MyPayPalClientId',
+ *       'secret'   => 'MyPayPalSecret',
+ *       'testMode' => true, // Or false when you are ready for live transactions
+ *   ));
+ *
+ *   // Do a complete subscription transaction on the gateway
+ *   $transaction = $gateway->completeSubscription(array(
+ *       'transactionReference'     => $subscription_id,
+ *   ));
+ *   $response = $transaction->send();
+ *   if ($response->isSuccessful()) {
+ *       echo "Complete Subscription transaction was successful!\n";
+ *       $subscription_id = $response->getTransactionReference();
+ *       echo "Subscription reference = " . $subscription_id;
+ *   }
+ * </code>
+ *
+ * Note that the subscription_id that you get from calling the response's
+ * getTransactionReference() method at the end of the completeSubscription
+ * call will be different to the one that you got after calling the response's
+ * getTransactionReference() method at the end of the createSubscription
+ * call.  The one that you get from completeSubscription is the correct
+ * one to use going forwards (e.g. for cancelling or updating the subscription).
+ *
+ * ### Request Sample
+ *
+ * This is from the PayPal web site:
+ *
+ * <code>
+ * curl -v POST https://api.sandbox.paypal.com/v1/payments/billing-agreements/EC-0JP008296V451950C/agreement-execute \
+ *     -H 'Content-Type:application/json' \
+ *     -H 'Authorization: Bearer <Access-Token>' \
+ *     -d '{}'
+ * </code>
+ *
+ * ### Response Sample
+ *
+ * This is from the PayPal web site:
+ *
+ * <code>
+ * {
+ *     "id": "I-0LN988D3JACS",
+ *     "links": [
+ *         {
+ *             "href": "https://api.sandbox.paypal.com/v1/payments/billing-agreements/I-0LN988D3JACS",
+ *             "rel": "self",
+ *             "method": "GET"
+ *         }
+ *     ]
+ * }
+ * </code>
+ *
+ * @link https://developer.paypal.com/docs/api/#execute-an-agreement
+ * @see RestCreateSubscriptionRequest
+ * @see Omnipay\PayPal\RestGateway
+ */
+class RestCompleteSubscriptionRequest extends AbstractRestRequest
+{
+    public function getData()
+    {
+        $this->validate('transactionReference');
+        $data = array();
+
+        return $data;
+    }
+
+    /**
+     * Get transaction endpoint.
+     *
+     * Complete Subscriptions are created using the /purchases resource.
+     *
+     * @return string
+     */
+    protected function getEndpoint()
+    {
+        return parent::getEndpoint() . '/payments/billing-agreements/' . $this->getTransactionReference() . '/execute';
+    }
+
+    protected function createResponse($data, $statusCode)
+    {
+        return $this->response = new RestAuthorizeResponse($this, $data, $statusCode);
+    }
+}

--- a/src/Message/RestCompleteSubscriptionRequest.php
+++ b/src/Message/RestCompleteSubscriptionRequest.php
@@ -114,6 +114,6 @@ class RestCompleteSubscriptionRequest extends AbstractRestRequest
      */
     protected function getEndpoint()
     {
-        return parent::getEndpoint() . '/payments/billing-agreements/' . $this->getTransactionReference() . '/execute';
+        return parent::getEndpoint() . '/payments/billing-agreements/' . $this->getTransactionReference() . '/agreement-execute';
     }
 }

--- a/src/Message/RestCreatePlanRequest.php
+++ b/src/Message/RestCreatePlanRequest.php
@@ -312,7 +312,7 @@ class RestCreatePlanRequest extends AbstractRestRequest
     /**
      * Get transaction endpoint.
      *
-     * Create Plans are created using the /purchases resource.
+     * Billing plans are created using the /billing-plans resource.
      *
      * @return string
      */

--- a/src/Message/RestCreatePlanRequest.php
+++ b/src/Message/RestCreatePlanRequest.php
@@ -192,7 +192,7 @@ namespace Omnipay\PayPal\Message;
  * @link https://developer.paypal.com/docs/api/#create-a-plan
  * @see Omnipay\PayPal\RestGateway
  */
-class CreatePlanRequest extends AbstractRestRequest
+class RestCreatePlanRequest extends AbstractRestRequest
 {
     /**
      * Get the plan name
@@ -208,7 +208,7 @@ class CreatePlanRequest extends AbstractRestRequest
      * Set the plan name
      *
      * @param string $value
-     * @return CreatePlanRequest provides a fluent interface.
+     * @return RestCreatePlanRequest provides a fluent interface.
      */
     public function setName($value)
     {
@@ -230,7 +230,7 @@ class CreatePlanRequest extends AbstractRestRequest
      *
      * @param string $value either RestGateway::BILLING_PLAN_TYPE_FIXED
      *                      or RestGateway::BILLING_PLAN_TYPE_INFINITE
-     * @return CreatePlanRequest provides a fluent interface.
+     * @return RestCreatePlanRequest provides a fluent interface.
      */
     public function setType($value)
     {
@@ -258,7 +258,7 @@ class CreatePlanRequest extends AbstractRestRequest
      * a description of the array elements.
      *
      * @param array $value
-     * @return CreatePlanRequest provides a fluent interface.
+     * @return RestCreatePlanRequest provides a fluent interface.
      * @link https://developer.paypal.com/docs/api/#paymentdefinition-object
      */
     public function setPaymentDefinitions(array $value)
@@ -287,7 +287,7 @@ class CreatePlanRequest extends AbstractRestRequest
      * a description of the array elements.
      *
      * @param array $value
-     * @return CreatePlanRequest provides a fluent interface.
+     * @return RestCreatePlanRequest provides a fluent interface.
      * @link https://developer.paypal.com/docs/api/#merchantpreferences-object
      */
     public function setMerchantPreferences(array $value)
@@ -297,8 +297,6 @@ class CreatePlanRequest extends AbstractRestRequest
 
     public function getData()
     {
-        // An amount parameter is required.  All amounts are in
-        // Australian dollars.
         $this->validate('name', 'description', 'type');
         $data = array(
             'name'                  => $this->getName(),

--- a/src/Message/RestCreatePlanRequest.php
+++ b/src/Message/RestCreatePlanRequest.php
@@ -1,0 +1,246 @@
+<?php
+/**
+ * PayPal REST Create Plan Request
+ */
+
+namespace Omnipay\PayPal\Message;
+
+/**
+ * PayPal REST Create Plan Request
+ *
+ * PayPal offers merchants a /billing-plans resource for providing billing plans
+ * to users for recurring payments.
+ *
+ * After the billing plan is created, the /billing-agreements resource provides
+ * billing agreements so that users can agree to be billed for the plans.
+ *
+ * You can create an empty billing plan and add a trial period and/or regular
+ * billing. Alternatively, you can create a fully loaded plan that includes both
+ * a trial period and regular billing. Note: By default, a created billing plan
+ * is in a CREATED state. A user cannot subscribe to the billing plan unless it
+ * has been set to the ACTIVE state.
+ *
+ * In order to create a new billing plan you must submit the following details:
+ *
+ * * name (string). Required.
+ * * description (string). Required.
+ * * type (string). Allowed values: FIXED, INFINITE. Required.
+ * * payment_definitions (array)
+ * * merchant_preferences (object)
+ *
+ * ### Example
+ *
+ * <code>
+ *   // Create a gateway for the PayPal REST Gateway
+ *   // (routes to GatewayFactory::create)
+ *   $gateway = Omnipay::create('Paypal_Rest');
+ *
+ *   // Initialise the gateway
+ *   $gateway->initialize(array(
+ *       'clientId' => 'MyPayPalClientId',
+ *       'secret'   => 'MyPayPalSecret',
+ *       'testMode' => true, // Or false when you are ready for live transactions
+ *   ));
+ *
+ *   // Do a create plan transaction on the gateway
+ *   $transaction = $gateway->createPlan(array(
+ *       'name'                     => 'Test Plan',
+ *       'description'              => 'A plan created for testing',
+ *   ));
+ *   $response = $transaction->send();
+ *   if ($response->isSuccessful()) {
+ *       echo "Create Plan transaction was successful!\n";
+ *       $plan_id = $response->getTransactionReference();
+ *       echo "Plan reference = " . $plan_id . "\n";
+ *   }
+ * </code>
+ *
+ * ### Request Sample
+ *
+ * This is from the PayPal web site:
+ *
+ * <code>
+ * curl -v POST https://api.sandbox.paypal.com/v1/payments/billing-plans \
+ * -H 'Content-Type:application/json' \
+ * -H 'Authorization: Bearer <Access-Token>' \
+ * -d '{
+ *     "name": "T-Shirt of the Month Club Plan",
+ *     "description": "Template creation.",
+ *     "type": "fixed",
+ *     "payment_definitions": [
+ *         {
+ *             "name": "Regular Payments",
+ *             "type": "REGULAR",
+ *             "frequency": "MONTH",
+ *             "frequency_interval": "2",
+ *             "amount": {
+ *                 "value": "100",
+ *                 "currency": "USD"
+ *             },
+ *             "cycles": "12",
+ *             "charge_models": [
+ *                 {
+ *                     "type": "SHIPPING",
+ *                     "amount": {
+ *                         "value": "10",
+ *                         "currency": "USD"
+ *                     }
+ *                 },
+ *                 {
+ *                     "type": "TAX",
+ *                     "amount": {
+ *                         "value": "12",
+ *                         "currency": "USD"
+ *                     }
+ *                 }
+ *             ]
+ *         }
+ *     ],
+ *     "merchant_preferences": {
+ *         "setup_fee": {
+ *             "value": "1",
+ *             "currency": "USD"
+ *         },
+ *         "return_url": "http://www.return.com",
+ *         "cancel_url": "http://www.cancel.com",
+ *         "auto_bill_amount": "YES",
+ *         "initial_fail_amount_action": "CONTINUE",
+ *         "max_fail_attempts": "0"
+ *     }
+ * }'
+ * </code>
+ *
+ * @link https://developer.paypal.com/docs/api/#create-a-plan
+ * @see Omnipay\PayPal\RestGateway
+ */
+class CreatePlanRequest extends AbstractRestRequest
+{
+    /**
+     * Get the plan name
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->getParameter('name');
+    }
+
+    /**
+     * Set the plan name
+     *
+     * @param string $value
+     * @return CreatePlanRequest provides a fluent interface.
+     */
+    public function setName($value)
+    {
+        return $this->setParameter('name', $value);
+    }
+
+    /**
+     * Get the plan type
+     *
+     * @return string
+     */
+    public function getType()
+    {
+        return $this->getParameter('type');
+    }
+
+    /**
+     * Set the plan type
+     *
+     * @param string $value either RestGateway::BILLING_PLAN_TYPE_FIXED
+     *                      or RestGateway::BILLING_PLAN_TYPE_INFINITE
+     * @return CreatePlanRequest provides a fluent interface.
+     */
+    public function setType($value)
+    {
+        return $this->setParameter('type', $value);
+    }
+
+    /**
+     * Get the plan payment definitions
+     *
+     * See the class documentation and the PayPal REST API documentation for
+     * a description of the array elements.
+     *
+     * @return array
+     * @link https://developer.paypal.com/docs/api/#paymentdefinition-object
+     */
+    public function getPaymentDefinitions()
+    {
+        return $this->getParameter('paymentDefinitions');
+    }
+
+    /**
+     * Set the plan payment definitions
+     *
+     * See the class documentation and the PayPal REST API documentation for
+     * a description of the array elements.
+     *
+     * @param array $value
+     * @return CreatePlanRequest provides a fluent interface.
+     * @link https://developer.paypal.com/docs/api/#paymentdefinition-object
+     */
+    public function setPaymentDefinitions($value)
+    {
+        return $this->setParameter('paymentDefinitions', $value);
+    }
+
+    /**
+     * Get the plan merchant preferences
+     *
+     * See the class documentation and the PayPal REST API documentation for
+     * a description of the array elements.
+     *
+     * @return array
+     * @link https://developer.paypal.com/docs/api/#merchantpreferences-object
+     */
+    public function getMerchantPreferences()
+    {
+        return $this->getParameter('merchantPreferences');
+    }
+
+    /**
+     * Set the plan merchant preferences
+     *
+     * See the class documentation and the PayPal REST API documentation for
+     * a description of the array elements.
+     *
+     * @param array $value
+     * @return CreatePlanRequest provides a fluent interface.
+     * @link https://developer.paypal.com/docs/api/#merchantpreferences-object
+     */
+    public function setMerchantPreferences($value)
+    {
+        return $this->setParameter('merchantPreferences', $value);
+    }
+
+    public function getData()
+    {
+        // An amount parameter is required.  All amounts are in
+        // Australian dollars.
+        $this->validate('name', 'description', 'type');
+        $data = array(
+            'name'                  => $this->getName(),
+            'description'           => $this->getDescription(),
+            'type'                  => $this->getType(),
+            'payment_definitions'   => $this->getPaymentDefinitions(),
+            'merchant_preferences'  => $this->getMerchantPreferences(),
+        );
+
+        return $data;
+    }
+
+    /**
+     * Get transaction endpoint.
+     *
+     * Create Plans are created using the /purchases resource.
+     *
+     * @return string
+     */
+    protected function getEndpoint()
+    {
+        return parent::getEndpoint() . '/payments/billing-plans';
+    }
+}

--- a/src/Message/RestCreatePlanRequest.php
+++ b/src/Message/RestCreatePlanRequest.php
@@ -20,6 +20,8 @@ namespace Omnipay\PayPal\Message;
  * is in a CREATED state. A user cannot subscribe to the billing plan unless it
  * has been set to the ACTIVE state.
  *
+ * ### Request Data
+ *
  * In order to create a new billing plan you must submit the following details:
  *
  * * name (string). Required.
@@ -46,6 +48,17 @@ namespace Omnipay\PayPal\Message;
  *   $transaction = $gateway->createPlan(array(
  *       'name'                     => 'Test Plan',
  *       'description'              => 'A plan created for testing',
+ *       'type'                     => $gateway::BILLING_PLAN_TYPE_FIXED,
+ *       'paymentDefinitions'       => [
+ *           [
+ *               'name'                 => 'Monthly Payments for 12 months',
+ *               'type'                 => $gateway::PAYMENT_TRIAL,
+ *               'frequency'            => $gateway::BILLING_PLAN_FREQUENCY_MONTH,
+ *               'frequency_interval'   => 1,
+ *               'cycles'               => 12,
+ *               'amount'               => ['value' => 10.00, 'currency' => 'USD'],
+ *           ],
+ *       ],
  *   ));
  *   $response = $transaction->send();
  *   if ($response->isSuccessful()) {
@@ -108,6 +121,72 @@ namespace Omnipay\PayPal\Message;
  *         "max_fail_attempts": "0"
  *     }
  * }'
+ * </code>
+ *
+ * ### Response Sample
+ *
+ * This is from the PayPal web site:
+ *
+ * <code>
+ * {
+ *     "id": "P-94458432VR012762KRWBZEUA",
+ *     "state": "CREATED",
+ *     "name": "T-Shirt of the Month Club Plan",
+ *     "description": "Template creation.",
+ *     "type": "FIXED",
+ *     "payment_definitions": [
+ *         {
+ *             "id": "PD-50606817NF8063316RWBZEUA",
+ *             "name": "Regular Payments",
+ *             "type": "REGULAR",
+ *             "frequency": "Month",
+ *             "amount": {
+ *                 "currency": "USD",
+ *                 "value": "100"
+ *             },
+ *             "charge_models": [
+ *                 {
+ *                     "id": "CHM-55M5618301871492MRWBZEUA",
+ *                     "type": "SHIPPING",
+ *                     "amount": {
+ *                         "currency": "USD",
+ *                         "value": "10"
+ *                     }
+ *                 },
+ *                 {
+ *                     "id": "CHM-92S85978TN737850VRWBZEUA",
+ *                     "type": "TAX",
+ *                     "amount": {
+ *                         "currency": "USD",
+ *                         "value": "12"
+ *                     }
+ *                 }
+ *             ],
+ *             "cycles": "12",
+ *             "frequency_interval": "2"
+ *         }
+ *     ],
+ *     "merchant_preferences": {
+ *         "setup_fee": {
+ *             "currency": "USD",
+ *             "value": "1"
+ *         },
+ *         "max_fail_attempts": "0",
+ *         "return_url": "http://www.return.com",
+ *         "cancel_url": "http://www.cancel.com",
+ *         "auto_bill_amount": "YES",
+ *         "initial_fail_amount_action": "CONTINUE"
+ *     },
+ *     "create_time": "2014-07-31T17:41:55.920Z",
+ *     "update_time": "2014-07-31T17:41:55.920Z",
+ *     "links": [
+ *         {
+ *             "href": "https://api.sandbox.paypal.com/v1/payments/billing-plans/P-94458432VR012762KRWBZEUA",
+ *             "rel": "self",
+ *             "method": "GET"
+ *         }
+ *     ]
+ * }
  * </code>
  *
  * @link https://developer.paypal.com/docs/api/#create-a-plan
@@ -182,7 +261,7 @@ class CreatePlanRequest extends AbstractRestRequest
      * @return CreatePlanRequest provides a fluent interface.
      * @link https://developer.paypal.com/docs/api/#paymentdefinition-object
      */
-    public function setPaymentDefinitions($value)
+    public function setPaymentDefinitions(array $value)
     {
         return $this->setParameter('paymentDefinitions', $value);
     }
@@ -211,7 +290,7 @@ class CreatePlanRequest extends AbstractRestRequest
      * @return CreatePlanRequest provides a fluent interface.
      * @link https://developer.paypal.com/docs/api/#merchantpreferences-object
      */
-    public function setMerchantPreferences($value)
+    public function setMerchantPreferences(array $value)
     {
         return $this->setParameter('merchantPreferences', $value);
     }

--- a/src/Message/RestCreateSubscriptionRequest.php
+++ b/src/Message/RestCreateSubscriptionRequest.php
@@ -1,0 +1,451 @@
+<?php
+/**
+ * PayPal REST Create Subscription Request
+ */
+
+namespace Omnipay\PayPal\Message;
+
+/**
+ * PayPal REST Create Subscription Request
+ *
+ * Use this call to create a billing agreement for the buyer. The response
+ * for this call includes these HATEOAS links: an approval_url link and an
+ * execute link. Each returned link includes the token for the agreement.
+ *
+ * For PayPal payments:
+ *
+ * * After successfully creating the agreement, direct the user to the
+ *   approval_url on the PayPal site so that the user can approve the agreement.
+ * * Call the execute link to execute the billing agreement.
+ *
+ * Note: Billing agreements for credit card payments execute automatically
+ * when created. There is no need for the user to approve the agreement or
+ * to execute the agreement.
+ *
+ * ### Request Data
+ *
+ * Pass the agreement details in the body of a POST call, including the
+ * following agreement object properties:
+ *
+ * * name (string). Required.
+ * * description (string). Required.
+ * * start_date (string). Format yyyy-MM-dd z, as defined in ISO8601. Required.
+ * * agreement_details (array)
+ * * payer (array). Required
+ * * shipping_address (array).  Should be provided if it is different to the
+ *   default address.
+ * * override_merchant_preferences (array).
+ * * override_charge_models (array).
+ * * plan (array). Required.
+ *
+ * ### Example
+ *
+ * <code>
+ *   // Create a gateway for the PayPal REST Gateway
+ *   // (routes to GatewayFactory::create)
+ *   $gateway = Omnipay::create('Paypal_Rest');
+ *
+ *   // Initialise the gateway
+ *   $gateway->initialize(array(
+ *       'clientId' => 'MyPayPalClientId',
+ *       'secret'   => 'MyPayPalSecret',
+ *       'testMode' => true, // Or false when you are ready for live transactions
+ *   ));
+ *
+ *   // Do a create plan transaction on the gateway
+ *   $transaction = $gateway->createPlan(array(
+ *       'name'                     => 'Test Plan',
+ *       'description'              => 'A plan created for testing',
+ *       'type'                     => $gateway::BILLING_PLAN_TYPE_FIXED,
+ *       'paymentDefinitions'       => [
+ *           [
+ *               'name'                 => 'Monthly Payments for 12 months',
+ *               'type'                 => $gateway::PAYMENT_TRIAL,
+ *               'frequency'            => $gateway::BILLING_PLAN_FREQUENCY_MONTH,
+ *               'frequency_interval'   => 1,
+ *               'cycles'               => 12,
+ *               'amount'               => ['value' => 10.00, 'currency' => 'USD'],
+ *           ],
+ *       ],
+ *   ));
+ *   $response = $transaction->send();
+ *   if ($response->isSuccessful()) {
+ *       echo "Create Plan transaction was successful!\n";
+ *       $plan_id = $response->getTransactionReference();
+ *       echo "Plan reference = " . $plan_id . "\n";
+ *   }
+ *
+ *   // Do a create subscription transaction on the gateway
+ *   $transaction = $gateway->createSubscription(array(
+ *       'name'                     => 'Test Subscription',
+ *       'description'              => 'A subscription created for testing',
+ *       'startDate'                => new \DateTime(), // now
+ *       'planId'                   => $plan_id,
+ *       'payerDetails              => ['payment_method' => 'paypal'],
+ *   ));
+ *   $response = $transaction->send();
+ *   if ($response->isSuccessful()) {
+ *       echo "Create Subscription transaction was successful!\n";
+ *       if ($response->isRedirect()) {
+ *           echo "Response is a redirect\n";
+ *           echo "Redirect URL = " . $response->getRedirectUrl();
+ *       }
+ *   }
+ * </code>
+ *
+ * ### Request Sample
+ *
+ * This is from the PayPal web site:
+ *
+ * <code>
+ * curl -v POST https://api.sandbox.paypal.com/v1/payments/billing-agreements \
+ *     -H 'Content-Type:application/json' \
+ *     -H 'Authorization: Bearer <Access-Token>' \
+ *     -d '{
+ *         "name": "T-Shirt of the Month Club Agreement",
+ *         "description": "Agreement for T-Shirt of the Month Club Plan",
+ *         "start_date": "2015-02-19T00:37:04Z",
+ *         "plan": {
+ *             "id": "P-94458432VR012762KRWBZEUA"
+ *         },
+ *         "payer": {
+ *             "payment_method": "paypal"
+ *         },
+ *         "shipping_address": {
+ *             "line1": "111 First Street",
+ *             "city": "Saratoga",
+ *             "state": "CA",
+ *             "postal_code": "95070",
+ *             "country_code": "US"
+ *         }
+ *     }'
+ * }'
+ * </code>
+ *
+ * ### Response Sample
+ *
+ * This is from the PayPal web site:
+ *
+ * <code>
+ * {
+ *     "name": "T-Shirt of the Month Club Agreement",
+ *     "description": "Agreement for T-Shirt of the Month Club Plan",
+ *     "plan": {
+ *         "id": "P-94458432VR012762KRWBZEUA",
+ *         "state": "ACTIVE",
+ *         "name": "T-Shirt of the Month Club Plan",
+ *         "description": "Template creation.",
+ *         "type": "FIXED",
+ *         "payment_definitions": [
+ *             {
+ *                 "id": "PD-50606817NF8063316RWBZEUA",
+ *                 "name": "Regular Payments",
+ *                 "type": "REGULAR",
+ *                 "frequency": "Month",
+ *                 "amount": {
+ *                     "currency": "USD",
+ *                     "value": "100"
+ *                 },
+ *                 "charge_models": [
+ *                     {
+ *                         "id": "CHM-92S85978TN737850VRWBZEUA",
+ *                         "type": "TAX",
+ *                         "amount": {
+ *                             "currency": "USD",
+ *                             "value": "12"
+ *                         }
+ *                     },
+ *                     {
+ *                         "id": "CHM-55M5618301871492MRWBZEUA",
+ *                         "type": "SHIPPING",
+ *                         "amount": {
+ *                             "currency": "USD",
+ *                             "value": "10"
+ *                         }
+ *                     }
+ *                 ],
+ *                 "cycles": "12",
+ *                 "frequency_interval": "2"
+ *             }
+ *         ],
+ *         "merchant_preferences": {
+ *             "setup_fee": {
+ *                 "currency": "USD",
+ *                 "value": "1"
+ *             },
+ *             "max_fail_attempts": "0",
+ *             "return_url": "http://www.return.com",
+ *             "cancel_url": "http://www.cancel.com",
+ *             "auto_bill_amount": "YES",
+ *             "initial_fail_amount_action": "CONTINUE"
+ *         }
+ *     },
+ *     "links": [
+ *         {
+ *             "href": "https://www.sandbox.paypal.com/cgi-bin/webscr?cmd=_express-checkout&token=EC-0JP008296V451950C",
+ *             "rel": "approval_url",
+ *             "method": "REDIRECT"
+ *         },
+ *         {
+ *             "href": "https://api.sandbox.paypal.com/v1/payments/billing-agreements/EC-0JP008296V451950C/agreement-execute",
+ *             "rel": "execute",
+ *             "method": "POST"
+ *         }
+ *     ],
+ *     "start_date": "2015-02-19T00:37:04Z"
+ * }
+ * </code>
+ *
+ * @link https://developer.paypal.com/docs/api/#create-an-agreement
+ * @see RestCreatePlanRequest
+ * @see Omnipay\PayPal\RestGateway
+ */
+class CreateSubscriptionRequest extends AbstractRestRequest
+{
+    /**
+     * Get the agreement name
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->getParameter('name');
+    }
+
+    /**
+     * Set the agreement name
+     *
+     * @param string $value
+     * @return CreateSubscriptionRequest provides a fluent interface.
+     */
+    public function setName($value)
+    {
+        return $this->setParameter('name', $value);
+    }
+
+    /**
+     * Get the plan ID
+     *
+     * @return string
+     */
+    public function getPlanId()
+    {
+        return $this->getParameter('planId');
+    }
+
+    /**
+     * Set the plan ID
+     *
+     * @param string $value
+     * @return CreateSubscriptionRequest provides a fluent interface.
+     */
+    public function setPlanId($value)
+    {
+        return $this->setParameter('planId', $value);
+    }
+
+    /**
+     * Get the agreement start date
+     *
+     * @return \DateTime
+     */
+    public function getStartDate()
+    {
+        return $this->getParameter('startDate');
+    }
+
+    /**
+     * Set the agreement start date
+     *
+     * @param \DateTime $value
+     * @return CreateSubscriptionRequest provides a fluent interface.
+     */
+    public function setStartDate(\DateTime $value)
+    {
+        return $this->setParameter('startDate', $value);
+    }
+
+    /**
+     * Get the agreement details
+     *
+     * See the class documentation and the PayPal REST API documentation for
+     * a description of the array elements.
+     *
+     * @return array
+     * @link https://developer.paypal.com/docs/api/#agreementdetails-object
+     */
+    public function getAgreementDetails()
+    {
+        return $this->getParameter('agreementDetails');
+    }
+
+    /**
+     * Set the agreement details
+     *
+     * See the class documentation and the PayPal REST API documentation for
+     * a description of the array elements.
+     *
+     * @param array $value
+     * @return CreateSubscriptionRequest provides a fluent interface.
+     * @link https://developer.paypal.com/docs/api/#agreementdetails-object
+     */
+    public function setAgreementDetails(array $value)
+    {
+        return $this->setParameter('agreementDetails', $value);
+    }
+
+    /**
+     * Get the payer details
+     *
+     * See the class documentation and the PayPal REST API documentation for
+     * a description of the array elements.
+     *
+     * @return array
+     * @link https://developer.paypal.com/docs/api/#payer-object
+     */
+    public function getPayerDetails()
+    {
+        return $this->getParameter('payerDetails');
+    }
+
+    /**
+     * Set the payer details
+     *
+     * See the class documentation and the PayPal REST API documentation for
+     * a description of the array elements.
+     *
+     * @param array $value
+     * @return CreateSubscriptionRequest provides a fluent interface.
+     * @link https://developer.paypal.com/docs/api/#payer-object
+     */
+    public function setPayerDetails(array $value)
+    {
+        return $this->setParameter('payerDetails', $value);
+    }
+
+    /**
+     * Get the shipping address
+     *
+     * See the class documentation and the PayPal REST API documentation for
+     * a description of the array elements.
+     *
+     * @return array
+     * @link https://developer.paypal.com/docs/api/#address-object
+     */
+    public function getShippingAddress()
+    {
+        return $this->getParameter('shippingAddress');
+    }
+
+    /**
+     * Set the shipping address
+     *
+     * See the class documentation and the PayPal REST API documentation for
+     * a description of the array elements.
+     *
+     * @param array $value
+     * @return CreateSubscriptionRequest provides a fluent interface.
+     * @link https://developer.paypal.com/docs/api/#address-object
+     */
+    public function setShippingAddress(array $value)
+    {
+        return $this->setParameter('shippingAddress', $value);
+    }
+
+    /**
+     * Get preferences to override the plan merchant preferences
+     *
+     * See the class documentation and the PayPal REST API documentation for
+     * a description of the array elements.
+     *
+     * @return array
+     * @link https://developer.paypal.com/docs/api/#merchantpreferences-object
+     */
+    public function getMerchantPreferences()
+    {
+        return $this->getParameter('merchantPreferences');
+    }
+
+    /**
+     * Set preferences to override the plan merchant preferences
+     *
+     * See the class documentation and the PayPal REST API documentation for
+     * a description of the array elements.
+     *
+     * @param array $value
+     * @return CreateSubscriptionRequest provides a fluent interface.
+     * @link https://developer.paypal.com/docs/api/#merchantpreferences-object
+     */
+    public function setMerchantPreferences(array $value)
+    {
+        return $this->setParameter('merchantPreferences', $value);
+    }
+
+    /**
+     * Get charge model to override the plan charge model
+     *
+     * See the class documentation and the PayPal REST API documentation for
+     * a description of the array elements.
+     *
+     * @return array
+     * @link https://developer.paypal.com/docs/api/#overridechargemodel-object
+     */
+    public function getChargeModel()
+    {
+        return $this->getParameter('chargeModel');
+    }
+
+    /**
+     * Set preferences to override the plan merchant preferences
+     *
+     * See the class documentation and the PayPal REST API documentation for
+     * a description of the array elements.
+     *
+     * @param array $value
+     * @return CreateSubscriptionRequest provides a fluent interface.
+     * @link https://developer.paypal.com/docs/api/#merchantpreferences-object
+     */
+    public function setChargeModel(array $value)
+    {
+        return $this->setParameter('merchantPreferences', $value);
+    }
+
+    public function getData()
+    {
+        // An amount parameter is required.  All amounts are in
+        // Australian dollars.
+        $this->validate('name', 'description', 'startDate', 'payer', 'planId');
+        $data = array(
+            'name'                              => $this->getName(),
+            'description'                       => $this->getDescription(),
+            'start_date'                        => $this->getStartDate()->format('c'),
+            'agreement_details'                 => $this->getAgreementDetails(),
+            'payer'                             => $this->getPayerDetails(),
+            'plan'                              => [
+                'id'    => $this->getPlanId(),
+            ],
+            'shipping_address'                  => $this->getShippingAddress(),
+            'override_merchant_preferences'     => $this->getMerchantPreferences(),
+            'override_charge_models'            => $this->getChargeModel(),
+        );
+
+        return $data;
+    }
+
+    /**
+     * Get transaction endpoint.
+     *
+     * Create Subscriptions are created using the /purchases resource.
+     *
+     * @return string
+     */
+    protected function getEndpoint()
+    {
+        return parent::getEndpoint() . '/payments/billing-agreements';
+    }
+
+    protected function createResponse($data, $statusCode)
+    {
+        return $this->response = new RestAuthorizeResponse($this, $data, $statusCode);
+    }
+}

--- a/src/Message/RestCreateSubscriptionRequest.php
+++ b/src/Message/RestCreateSubscriptionRequest.php
@@ -202,7 +202,7 @@ namespace Omnipay\PayPal\Message;
  * @see RestCreatePlanRequest
  * @see Omnipay\PayPal\RestGateway
  */
-class RestCompleteSubscriptionRequest extends AbstractRestRequest
+class RestCreateSubscriptionRequest extends AbstractRestRequest
 {
     /**
      * Get the agreement name
@@ -218,7 +218,7 @@ class RestCompleteSubscriptionRequest extends AbstractRestRequest
      * Set the agreement name
      *
      * @param string $value
-     * @return RestCompleteSubscriptionRequest provides a fluent interface.
+     * @return RestCreateSubscriptionRequest provides a fluent interface.
      */
     public function setName($value)
     {
@@ -239,7 +239,7 @@ class RestCompleteSubscriptionRequest extends AbstractRestRequest
      * Set the plan ID
      *
      * @param string $value
-     * @return RestCompleteSubscriptionRequest provides a fluent interface.
+     * @return RestCreateSubscriptionRequest provides a fluent interface.
      */
     public function setPlanId($value)
     {
@@ -260,7 +260,7 @@ class RestCompleteSubscriptionRequest extends AbstractRestRequest
      * Set the agreement start date
      *
      * @param \DateTime $value
-     * @return RestCompleteSubscriptionRequest provides a fluent interface.
+     * @return RestCreateSubscriptionRequest provides a fluent interface.
      */
     public function setStartDate(\DateTime $value)
     {
@@ -288,7 +288,7 @@ class RestCompleteSubscriptionRequest extends AbstractRestRequest
      * a description of the array elements.
      *
      * @param array $value
-     * @return RestCompleteSubscriptionRequest provides a fluent interface.
+     * @return RestCreateSubscriptionRequest provides a fluent interface.
      * @link https://developer.paypal.com/docs/api/#agreementdetails-object
      */
     public function setAgreementDetails(array $value)
@@ -317,7 +317,7 @@ class RestCompleteSubscriptionRequest extends AbstractRestRequest
      * a description of the array elements.
      *
      * @param array $value
-     * @return RestCompleteSubscriptionRequest provides a fluent interface.
+     * @return RestCreateSubscriptionRequest provides a fluent interface.
      * @link https://developer.paypal.com/docs/api/#payer-object
      */
     public function setPayerDetails(array $value)
@@ -346,7 +346,7 @@ class RestCompleteSubscriptionRequest extends AbstractRestRequest
      * a description of the array elements.
      *
      * @param array $value
-     * @return RestCompleteSubscriptionRequest provides a fluent interface.
+     * @return RestCreateSubscriptionRequest provides a fluent interface.
      * @link https://developer.paypal.com/docs/api/#address-object
      */
     public function setShippingAddress(array $value)
@@ -375,7 +375,7 @@ class RestCompleteSubscriptionRequest extends AbstractRestRequest
      * a description of the array elements.
      *
      * @param array $value
-     * @return RestCompleteSubscriptionRequest provides a fluent interface.
+     * @return RestCreateSubscriptionRequest provides a fluent interface.
      * @link https://developer.paypal.com/docs/api/#merchantpreferences-object
      */
     public function setMerchantPreferences(array $value)
@@ -404,7 +404,7 @@ class RestCompleteSubscriptionRequest extends AbstractRestRequest
      * a description of the array elements.
      *
      * @param array $value
-     * @return RestCompleteSubscriptionRequest provides a fluent interface.
+     * @return RestCreateSubscriptionRequest provides a fluent interface.
      * @link https://developer.paypal.com/docs/api/#merchantpreferences-object
      */
     public function setChargeModel(array $value)
@@ -435,7 +435,7 @@ class RestCompleteSubscriptionRequest extends AbstractRestRequest
     /**
      * Get transaction endpoint.
      *
-     * Create Subscriptions are created using the /purchases resource.
+     * Subscriptions are created using the /billing-agreements resource.
      *
      * @return string
      */

--- a/src/Message/RestCreateSubscriptionRequest.php
+++ b/src/Message/RestCreateSubscriptionRequest.php
@@ -198,6 +198,12 @@ namespace Omnipay\PayPal\Message;
  * }
  * </code>
  *
+ * ### Known Issues
+ *
+ * PayPal subscription payments cannot be refunded. PayPal is working on this functionality
+ * for their future API release.  In order to refund a PayPal subscription payment, you will
+ * need to use the PayPal web interface to refund it manually.
+ *
  * @link https://developer.paypal.com/docs/api/#create-an-agreement
  * @see RestCreatePlanRequest
  * @see Omnipay\PayPal\RestGateway

--- a/src/Message/RestCreateSubscriptionRequest.php
+++ b/src/Message/RestCreateSubscriptionRequest.php
@@ -184,14 +184,14 @@ namespace Omnipay\PayPal\Message;
  *     },
  *     "links": [
  *         {
- *             "href": "https://www.sandbox.paypal.com/cgi-bin/webscr?cmd=_express-checkout&token=EC-0JP008296V451950C",
- *             "rel": "approval_url",
- *             "method": "REDIRECT"
+ * "href": "https://www.sandbox.paypal.com/cgi-bin/webscr?cmd=_express-checkout&token=EC-0JP008296V451950C",
+ * "rel": "approval_url",
+ * "method": "REDIRECT"
  *         },
  *         {
- *             "href": "https://api.sandbox.paypal.com/v1/payments/billing-agreements/EC-0JP008296V451950C/agreement-execute",
- *             "rel": "execute",
- *             "method": "POST"
+ * "href": "https://api.sandbox.paypal.com/v1/payments/billing-agreements/EC-0JP008296V451950C/agreement-execute",
+ * "rel": "execute",
+ * "method": "POST"
  *         }
  *     ],
  *     "start_date": "2015-02-19T00:37:04Z"

--- a/src/Message/RestCreateSubscriptionRequest.php
+++ b/src/Message/RestCreateSubscriptionRequest.php
@@ -414,7 +414,7 @@ class RestCreateSubscriptionRequest extends AbstractRestRequest
 
     public function getData()
     {
-        $this->validate('name', 'description', 'startDate', 'payer', 'planId');
+        $this->validate('name', 'description', 'startDate', 'payerDetails', 'planId');
         $data = array(
             'name'                              => $this->getName(),
             'description'                       => $this->getDescription(),

--- a/src/Message/RestCreateSubscriptionRequest.php
+++ b/src/Message/RestCreateSubscriptionRequest.php
@@ -409,7 +409,7 @@ class RestCreateSubscriptionRequest extends AbstractRestRequest
      */
     public function setChargeModel(array $value)
     {
-        return $this->setParameter('merchantPreferences', $value);
+        return $this->setParameter('chargeModel', $value);
     }
 
     public function getData()

--- a/src/Message/RestCreateSubscriptionRequest.php
+++ b/src/Message/RestCreateSubscriptionRequest.php
@@ -421,9 +421,9 @@ class RestCreateSubscriptionRequest extends AbstractRestRequest
             'start_date'                        => $this->getStartDate()->format('c'),
             'agreement_details'                 => $this->getAgreementDetails(),
             'payer'                             => $this->getPayerDetails(),
-            'plan'                              => [
+            'plan'                              => array(
                 'id'    => $this->getPlanId(),
-            ],
+            ),
             'shipping_address'                  => $this->getShippingAddress(),
             'override_merchant_preferences'     => $this->getMerchantPreferences(),
             'override_charge_models'            => $this->getChargeModel(),

--- a/src/Message/RestCreateSubscriptionRequest.php
+++ b/src/Message/RestCreateSubscriptionRequest.php
@@ -89,6 +89,8 @@ namespace Omnipay\PayPal\Message;
  *       if ($response->isRedirect()) {
  *           echo "Response is a redirect\n";
  *           echo "Redirect URL = " . $response->getRedirectUrl();
+ *           $subscription_id = $response->getTransactionReference();
+ *           echo "Subscription reference = " . $subscription_id;
  *       }
  *   }
  * </code>
@@ -200,7 +202,7 @@ namespace Omnipay\PayPal\Message;
  * @see RestCreatePlanRequest
  * @see Omnipay\PayPal\RestGateway
  */
-class CreateSubscriptionRequest extends AbstractRestRequest
+class RestCompleteSubscriptionRequest extends AbstractRestRequest
 {
     /**
      * Get the agreement name
@@ -216,7 +218,7 @@ class CreateSubscriptionRequest extends AbstractRestRequest
      * Set the agreement name
      *
      * @param string $value
-     * @return CreateSubscriptionRequest provides a fluent interface.
+     * @return RestCompleteSubscriptionRequest provides a fluent interface.
      */
     public function setName($value)
     {
@@ -237,7 +239,7 @@ class CreateSubscriptionRequest extends AbstractRestRequest
      * Set the plan ID
      *
      * @param string $value
-     * @return CreateSubscriptionRequest provides a fluent interface.
+     * @return RestCompleteSubscriptionRequest provides a fluent interface.
      */
     public function setPlanId($value)
     {
@@ -258,7 +260,7 @@ class CreateSubscriptionRequest extends AbstractRestRequest
      * Set the agreement start date
      *
      * @param \DateTime $value
-     * @return CreateSubscriptionRequest provides a fluent interface.
+     * @return RestCompleteSubscriptionRequest provides a fluent interface.
      */
     public function setStartDate(\DateTime $value)
     {
@@ -286,7 +288,7 @@ class CreateSubscriptionRequest extends AbstractRestRequest
      * a description of the array elements.
      *
      * @param array $value
-     * @return CreateSubscriptionRequest provides a fluent interface.
+     * @return RestCompleteSubscriptionRequest provides a fluent interface.
      * @link https://developer.paypal.com/docs/api/#agreementdetails-object
      */
     public function setAgreementDetails(array $value)
@@ -315,7 +317,7 @@ class CreateSubscriptionRequest extends AbstractRestRequest
      * a description of the array elements.
      *
      * @param array $value
-     * @return CreateSubscriptionRequest provides a fluent interface.
+     * @return RestCompleteSubscriptionRequest provides a fluent interface.
      * @link https://developer.paypal.com/docs/api/#payer-object
      */
     public function setPayerDetails(array $value)
@@ -344,7 +346,7 @@ class CreateSubscriptionRequest extends AbstractRestRequest
      * a description of the array elements.
      *
      * @param array $value
-     * @return CreateSubscriptionRequest provides a fluent interface.
+     * @return RestCompleteSubscriptionRequest provides a fluent interface.
      * @link https://developer.paypal.com/docs/api/#address-object
      */
     public function setShippingAddress(array $value)
@@ -373,7 +375,7 @@ class CreateSubscriptionRequest extends AbstractRestRequest
      * a description of the array elements.
      *
      * @param array $value
-     * @return CreateSubscriptionRequest provides a fluent interface.
+     * @return RestCompleteSubscriptionRequest provides a fluent interface.
      * @link https://developer.paypal.com/docs/api/#merchantpreferences-object
      */
     public function setMerchantPreferences(array $value)
@@ -402,7 +404,7 @@ class CreateSubscriptionRequest extends AbstractRestRequest
      * a description of the array elements.
      *
      * @param array $value
-     * @return CreateSubscriptionRequest provides a fluent interface.
+     * @return RestCompleteSubscriptionRequest provides a fluent interface.
      * @link https://developer.paypal.com/docs/api/#merchantpreferences-object
      */
     public function setChargeModel(array $value)
@@ -412,8 +414,6 @@ class CreateSubscriptionRequest extends AbstractRestRequest
 
     public function getData()
     {
-        // An amount parameter is required.  All amounts are in
-        // Australian dollars.
         $this->validate('name', 'description', 'startDate', 'payer', 'planId');
         $data = array(
             'name'                              => $this->getName(),

--- a/src/Message/RestReactivateSubscriptionRequest.php
+++ b/src/Message/RestReactivateSubscriptionRequest.php
@@ -1,19 +1,19 @@
 <?php
 /**
- * PayPal REST Cancel Subscription Request
+ * PayPal REST Reactivate Subscription Request
  */
 
 namespace Omnipay\PayPal\Message;
 
 /**
- * PayPal REST Cancel Subscription Request
+ * PayPal REST Reactivate Subscription Request
  *
- * Use this call to cancel an agreement after the buyer approves it.
+ * Use this call to reactivate an agreement.
  *
  * ### Request Data
  *
  * Pass the agreement id in the URI of a POST call.  Also include a description,
- * which is the reason for cancelling the subscription.
+ * which is the reason for reactivating the subscription.
  *
  * ### Example
  *
@@ -31,14 +31,14 @@ namespace Omnipay\PayPal\Message;
  *       'testMode' => true, // Or false when you are ready for live transactions
  *   ));
  *
- *   // Do a cancel subscription transaction on the gateway
- *   $transaction = $gateway->cancelSubscription(array(
+ *   // Do a reactivate subscription transaction on the gateway
+ *   $transaction = $gateway->reactivateSubscription(array(
  *       'transactionReference'     => $subscription_id,
- *       'description'              => "Cancelling the agreement.",
+ *       'description'              => "Reactivating the agreement.",
  *   ));
  *   $response = $transaction->send();
  *   if ($response->isSuccessful()) {
- *       echo "Cancel Subscription transaction was successful!\n";
+ *       echo "Reactivate Subscription transaction was successful!\n";
  *   }
  * </code>
  *
@@ -54,19 +54,19 @@ namespace Omnipay\PayPal\Message;
  * This is from the PayPal web site:
  *
  * <code>
- * curl -v POST https://api.sandbox.paypal.com/v1/payments/billing-agreements/I-0LN988D3JACS/cancel \
+ * curl -v POST https://api.sandbox.paypal.com/v1/payments/billing-agreements/I-0LN988D3JACS/re-activate \
  *     -H 'Content-Type:application/json' \
  *     -H 'Authorization: Bearer <Access-Token>' \
  *     -d '{
- *         "note": "Canceling the agreement."
+ *         "note": "Reactivating the agreement."
  *     }'
  * </code>
  *
- * @link https://developer.paypal.com/docs/api/#cancel-an-agreement
+ * @link https://developer.paypal.com/docs/api/#reactivate-an-agreement
  * @see RestCreateSubscriptionRequest
  * @see Omnipay\PayPal\RestGateway
  */
-class RestCancelSubscriptionRequest extends AbstractRestRequest
+class RestReactivateSubscriptionRequest extends AbstractRestRequest
 {
     public function getData()
     {
@@ -88,6 +88,6 @@ class RestCancelSubscriptionRequest extends AbstractRestRequest
     protected function getEndpoint()
     {
         return parent::getEndpoint() . '/payments/billing-agreements/' .
-            $this->getTransactionReference() . '/cancel';
+            $this->getTransactionReference() . '/re-activate';
     }
 }

--- a/src/Message/RestReactivateSubscriptionRequest.php
+++ b/src/Message/RestReactivateSubscriptionRequest.php
@@ -70,7 +70,7 @@ class RestReactivateSubscriptionRequest extends AbstractRestRequest
 {
     public function getData()
     {
-        $this->validate('transactionReference');
+        $this->validate('transactionReference', 'description');
         $data = array(
             'note'  => $this->getDescription(),
         );

--- a/src/Message/RestRefundRequest.php
+++ b/src/Message/RestRefundRequest.php
@@ -43,6 +43,12 @@ namespace Omnipay\PayPal\Message;
  *   }
  * </code>
  *
+ * ### Known Issues
+ *
+ * PayPal subscription payments cannot be refunded. PayPal is working on this functionality
+ * for their future API release.  In order to refund a PayPal subscription payment, you will
+ * need to use the PayPal web interface to refund it manually.
+ *
  * @see RestPurchaseRequest
  */
 class RestRefundRequest extends AbstractRestRequest

--- a/src/Message/RestSearchTransactionRequest.php
+++ b/src/Message/RestSearchTransactionRequest.php
@@ -95,6 +95,12 @@ namespace Omnipay\PayPal\Message;
  * }
  * </code>
  *
+ * ### Known Issues
+ *
+ * PayPal subscription payments cannot be refunded. PayPal is working on this functionality
+ * for their future API release.  In order to refund a PayPal subscription payment, you will
+ * need to use the PayPal web interface to refund it manually.
+ *
  * @see RestCreateSubscriptionRequest
  * @link https://developer.paypal.com/docs/api/#search-for-transactions
  */

--- a/src/Message/RestSearchTransactionRequest.php
+++ b/src/Message/RestSearchTransactionRequest.php
@@ -31,7 +31,7 @@ namespace Omnipay\PayPal\Message;
  * This is from the PayPal web site:
  *
  * <code>
- * curl -v GET https://api.sandbox.paypal.com/v1/payments/billing-agreements/I-0LN988D3JACS/transactions?start_date=yyyy-mm-dd&end_date=yyyy-mm-dd \
+ * curl -v GET https://api.sandbox.paypal.com/v1/payments/billing-agreements/I-0LN988D3JACS/transactions \
  *     -H 'Content-Type:application/json' \
  *     -H 'Authorization: Bearer <Access-Token>'
  * </code>

--- a/src/Message/RestSearchTransactionRequest.php
+++ b/src/Message/RestSearchTransactionRequest.php
@@ -1,0 +1,192 @@
+<?php
+/**
+ * PayPal REST Search Transaction Request
+ */
+
+namespace Omnipay\PayPal\Message;
+
+/**
+ * PayPal REST Search Transaction Request
+ *
+ * Use this call to search for the transactions within a billing agreement.
+ * Note that this is not a generic transaction search function -- for that
+ * see RestListPurchaseRequest.  It only searches for transactions within
+ * a billing agreement.
+ *
+ * This should be used on a regular basis to determine the success / failure
+ * state of transactions on active billing agreements.
+ *
+ * ### Example
+ *
+ * <code>
+ *   // List the transactions for a billing agreement.
+ *   $transaction = $gateway->listPurchase();
+ *   $response = $transaction->send();
+ *   $data = $response->getData();
+ *   echo "Gateway listPurchase response data == " . print_r($data, true) . "\n";
+ * </code>
+ *
+ * ### Request Sample
+ *
+ * This is from the PayPal web site:
+ *
+ * <code>
+ * curl -v GET https://api.sandbox.paypal.com/v1/payments/billing-agreements/I-0LN988D3JACS/transactions?start_date=yyyy-mm-dd&end_date=yyyy-mm-dd \
+ *     -H 'Content-Type:application/json' \
+ *     -H 'Authorization: Bearer <Access-Token>'
+ * </code>
+ *
+ * ### Response Sample
+ *
+ * This is from the PayPal web site:
+ *
+ * <code>
+ * {
+ *     "agreement_transaction_list": [
+ *         {
+ *             "transaction_id": "I-0LN988D3JACS",
+ *             "status": "Created",
+ *             "transaction_type": "Recurring Payment",
+ *             "payer_email": "bbuyer@example.com",
+ *             "payer_name": "Betsy Buyer",
+ *             "time_stamp": "2014-06-09T09:29:36Z",
+ *             "time_zone": "GMT"
+ *         },
+ *         {
+ *             "transaction_id": "928415314Y5640008",
+ *             "status": "Completed",
+ *             "transaction_type": "Recurring Payment",
+ *             "amount": {
+ *                 "currency": "USD",
+ *                 "value": "1.00"
+ *             },
+ *             "fee_amount": {
+ *                 "currency": "USD",
+ *                 "value": "-0.33"
+ *             },
+ *             "net_amount": {
+ *                 "currency": "USD",
+ *                 "value": "0.67"
+ *             },
+ *             "payer_email": "bbuyer@example.com",
+ *             "payer_name": "Betsy Buyer",
+ *             "time_stamp": "2014-06-09T09:42:47Z",
+ *             "time_zone": "GMT"
+ *         },
+ *         {
+ *             "transaction_id": "I-0LN988D3JACS",
+ *             "status": "Suspended",
+ *             "transaction_type": "Recurring Payment",
+ *             "payer_email": "bbuyer@example.com",
+ *             "payer_name": "Betsy Buyer",
+ *             "time_stamp": "2014-06-09T11:18:34Z",
+ *             "time_zone": "GMT"
+ *         },
+ *         {
+ *             "transaction_id": "I-0LN988D3JACS",
+ *             "status": "Reactivated",
+ *             "transaction_type": "Recurring Payment",
+ *             "payer_email": "bbuyer@example.com",
+ *             "payer_name": "Betsy Buyer",
+ *             "time_stamp": "2014-06-09T11:18:48Z",
+ *             "time_zone": "GMT"
+ *         }
+ *     ]
+ * }
+ * </code>
+ *
+ * @see RestCreateSubscriptionRequest
+ * @link https://developer.paypal.com/docs/api/#search-for-transactions
+ */
+class RestSearchTransactionRequest extends AbstractRestRequest
+{
+    /**
+     * Get the agreement ID
+     *
+     * @return string
+     */
+    public function getAgreementId()
+    {
+        return $this->getParameter('agreementId');
+    }
+
+    /**
+     * Set the agreement ID
+     *
+     * @param string $value
+     * @return RestSearchTransactionRequest provides a fluent interface.
+     */
+    public function setAgreementId($value)
+    {
+        return $this->setParameter('agreementId', $value);
+    }
+
+    /**
+     * Get the request startDate
+     *
+     * @return string
+     */
+    public function getStartDate()
+    {
+        return $this->getParameter('startDate');
+    }
+
+    /**
+     * Set the request startDate
+     *
+     * @param string $value
+     * @return RestSearchTransactionRequest provides a fluent interface.
+     */
+    public function setStartDate($value)
+    {
+        return $this->setParameter('startDate', $value);
+    }
+
+    /**
+     * Get the request endDate
+     *
+     * @return string
+     */
+    public function getEndDate()
+    {
+        return $this->getParameter('endDate');
+    }
+
+    /**
+     * Set the request endDate
+     *
+     * @param string $value
+     * @return RestSearchTransactionRequest provides a fluent interface.
+     */
+    public function setEndDate($value)
+    {
+        return $this->setParameter('endDate', $value);
+    }
+
+    public function getData()
+    {
+        $this->validate('agreementId');
+        return array(
+            'start_date'        => $this->getStartDate(),
+            'end_date'          => $this->getEndDate(),
+        );
+    }
+
+    /**
+     * Get HTTP Method.
+     *
+     * The HTTP method for searchTransaction requests must be GET.
+     *
+     * @return string
+     */
+    protected function getHttpMethod()
+    {
+        return 'GET';
+    }
+
+    public function getEndpoint()
+    {
+        return parent::getEndpoint() . '/payments/billing-agreements/' .
+            $this->getAgreementId() . '/transactions';
+    }
+}

--- a/src/Message/RestSuspendSubscriptionRequest.php
+++ b/src/Message/RestSuspendSubscriptionRequest.php
@@ -1,19 +1,19 @@
 <?php
 /**
- * PayPal REST Cancel Subscription Request
+ * PayPal REST Suspend Subscription Request
  */
 
 namespace Omnipay\PayPal\Message;
 
 /**
- * PayPal REST Cancel Subscription Request
+ * PayPal REST Suspend Subscription Request
  *
- * Use this call to cancel an agreement after the buyer approves it.
+ * Use this call to suspend an agreement.
  *
  * ### Request Data
  *
  * Pass the agreement id in the URI of a POST call.  Also include a description,
- * which is the reason for cancelling the subscription.
+ * which is the reason for suspending the subscription.
  *
  * ### Example
  *
@@ -31,14 +31,14 @@ namespace Omnipay\PayPal\Message;
  *       'testMode' => true, // Or false when you are ready for live transactions
  *   ));
  *
- *   // Do a cancel subscription transaction on the gateway
- *   $transaction = $gateway->cancelSubscription(array(
+ *   // Do a suspend subscription transaction on the gateway
+ *   $transaction = $gateway->suspendSubscription(array(
  *       'transactionReference'     => $subscription_id,
- *       'description'              => "Cancelling the agreement.",
+ *       'description'              => "Suspending the agreement.",
  *   ));
  *   $response = $transaction->send();
  *   if ($response->isSuccessful()) {
- *       echo "Cancel Subscription transaction was successful!\n";
+ *       echo "Suspend Subscription transaction was successful!\n";
  *   }
  * </code>
  *
@@ -54,19 +54,19 @@ namespace Omnipay\PayPal\Message;
  * This is from the PayPal web site:
  *
  * <code>
- * curl -v POST https://api.sandbox.paypal.com/v1/payments/billing-agreements/I-0LN988D3JACS/cancel \
+ * curl -v POST https://api.sandbox.paypal.com/v1/payments/billing-agreements/I-0LN988D3JACS/suspend \
  *     -H 'Content-Type:application/json' \
  *     -H 'Authorization: Bearer <Access-Token>' \
  *     -d '{
- *         "note": "Canceling the agreement."
+ *         "note": "Suspending the agreement."
  *     }'
  * </code>
  *
- * @link https://developer.paypal.com/docs/api/#cancel-an-agreement
+ * @link https://developer.paypal.com/docs/api/#suspend-an-agreement
  * @see RestCreateSubscriptionRequest
  * @see Omnipay\PayPal\RestGateway
  */
-class RestCancelSubscriptionRequest extends AbstractRestRequest
+class RestSuspendSubscriptionRequest extends AbstractRestRequest
 {
     public function getData()
     {
@@ -88,6 +88,6 @@ class RestCancelSubscriptionRequest extends AbstractRestRequest
     protected function getEndpoint()
     {
         return parent::getEndpoint() . '/payments/billing-agreements/' .
-            $this->getTransactionReference() . '/cancel';
+            $this->getTransactionReference() . '/suspend';
     }
 }

--- a/src/Message/RestSuspendSubscriptionRequest.php
+++ b/src/Message/RestSuspendSubscriptionRequest.php
@@ -70,7 +70,7 @@ class RestSuspendSubscriptionRequest extends AbstractRestRequest
 {
     public function getData()
     {
-        $this->validate('transactionReference');
+        $this->validate('transactionReference', 'description');
         $data = array(
             'note'  => $this->getDescription(),
         );

--- a/src/Message/RestUpdatePlanRequest.php
+++ b/src/Message/RestUpdatePlanRequest.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * PayPal REST Update Plan Request
+ */
+
+namespace Omnipay\PayPal\Message;
+
+/**
+ * PayPal REST Update Plan Request
+ *
+ * You can update the information for an existing billing plan. The state
+ * of a plan must be active before a billing agreement is created.
+ *
+ * ### Request Data
+ *
+ * Pass the billing plan id in the URI of a PATCH call, including the replace
+ * operation in the body. Other operations in the patch_request object will
+ * throw validation exceptions.
+ *
+ * ### Example
+ *
+ * To create the billing plan, see the code example in RestCreatePlanRequest.
+ *
+ * <code>
+ *   // Create a gateway for the PayPal REST Gateway
+ *   // (routes to GatewayFactory::create)
+ *   $gateway = Omnipay::create('Paypal_Rest');
+ *
+ *   // Initialise the gateway
+ *   $gateway->initialize(array(
+ *       'clientId' => 'MyPayPalClientId',
+ *       'secret'   => 'MyPayPalSecret',
+ *       'testMode' => true, // Or false when you are ready for live transactions
+ *   ));
+ *
+ *   // Update the billing plan
+ *   $transaction = $gateway->updatePlan(array(
+ *       'transactionReference'     => $plan_id,
+ *       'state'                    => $gateway::BILLING_PLAN_STATE_ACTIVE,
+ *   ));
+ *   $response = $transaction->send();
+ *   if ($response->isSuccessful()) {
+ *       echo "Update Plan transaction was successful!\n";
+ *   }
+ * </code>
+ *
+ * ### Request Sample
+ *
+ * This is from the PayPal web site:
+ *
+ * <code>
+ * curl -v -k -X PATCH 'https://api.sandbox.paypal.com/v1/payments/billing-plans/P-94458432VR012762KRWBZEUA' \
+ *    -H "Content-Type: application/json" \
+ *    -H "Authorization: Bearer <Access-Token>" \
+ *    -d '[
+ *        {
+ *            "path": "/",
+ *            "value": {
+ *                "state": "ACTIVE"
+ *            },
+ *            "op": "replace"
+ *        }
+ *    ]'
+ * </code>
+ *
+ * ### Response
+ *
+ * Returns the HTTP status of 200 if the call is successful.
+ *
+ * @link https://developer.paypal.com/docs/api/#update-a-plan
+ * @see RestCreateSubscriptionRequest
+ * @see Omnipay\PayPal\RestGateway
+ */
+class RestUpdatePlanRequest extends AbstractRestRequest
+{
+    /**
+     * Get the plan state
+     *
+     * @return string
+     */
+    public function getState()
+    {
+        return $this->getParameter('state');
+    }
+
+    /**
+     * Set the plan state
+     *
+     * @param string $value
+     * @return RestUpdatePlanRequest provides a fluent interface.
+     */
+    public function setState($value)
+    {
+        return $this->setParameter('state', $value);
+    }
+
+    public function getData()
+    {
+        $this->validate('transactionReference', 'state');
+        $data = array(array(
+            'path'      => '/',
+            'value'     => array(
+                'state'     => $this->getState(),
+            ),
+            'op'        => 'replace'
+        ));
+
+        return $data;
+    }
+
+    /**
+     * Get transaction endpoint.
+     *
+     * Billing plans are managed using the /billing-plans resource.
+     *
+     * @return string
+     */
+    protected function getEndpoint()
+    {
+        return parent::getEndpoint() . '/payments/billing-plans/' . $this->getTransactionReference();
+    }
+
+    protected function getHttpMethod()
+    {
+        return 'PATCH';
+    }
+}

--- a/src/RestGateway.php
+++ b/src/RestGateway.php
@@ -154,6 +154,8 @@ class RestGateway extends AbstractGateway
     const BILLING_PLAN_FREQUENCY_WEEK   = 'WEEK';
     const BILLING_PLAN_FREQUENCY_MONTH  = 'MONTH';
     const BILLING_PLAN_FREQUENCY_YEAR   = 'YEAR';
+    const PAYMENT_TRIAL                 = 'TRIAL';
+    const PAYMENT_REGULAR               = 'REGULAR';
 
     public function getName()
     {
@@ -509,7 +511,12 @@ class RestGateway extends AbstractGateway
     // TODO: Update a plan (required to set a plan active)
     // TODO: Retrieve a plan
     // TODO: List plans
-    // TODO: Create an agreement
+
+    public function createSubscription(array $parameters = array())
+    {
+        return $this->createRequest('\Omnipay\PayPal\Message\RestCreateSubscriptionRequest', $parameters);
+    }
+
     // TODO: Execute an agreement
     // TODO: Update an agreement
     // TODO: Retrieve an agreement

--- a/src/RestGateway.php
+++ b/src/RestGateway.php
@@ -503,6 +503,20 @@ class RestGateway extends AbstractGateway
     // Billing Plans and Agreements -- Set up recurring payments.
     // @link https://developer.paypal.com/docs/api/#billing-plans-and-agreements
     //
+
+    /**
+     * Create a billing plan.
+     *
+     * You can create an empty billing plan and add a trial period and/or regular
+     * billing. Alternatively, you can create a fully loaded plan that includes
+     * both a trial period and regular billing. Note: By default, a created billing
+     * plan is in a CREATED state. A user cannot subscribe to the billing plan
+     * unless it has been set to the ACTIVE state.
+     *
+     * @link https://developer.paypal.com/docs/api/#create-a-plan
+     * @param array $parameters
+     * @return \Omnipay\PayPal\Message\RestCreatePlanRequest
+     */
     public function createPlan(array $parameters = array())
     {
         return $this->createRequest('\Omnipay\PayPal\Message\RestCreatePlanRequest', $parameters);
@@ -512,12 +526,34 @@ class RestGateway extends AbstractGateway
     // TODO: Retrieve a plan
     // TODO: List plans
 
+    /**
+     * Create a subscription.
+     *
+     * Use this call to create a billing agreement for the buyer.
+     *
+     * @link https://developer.paypal.com/docs/api/#create-an-agreement
+     * @param array $parameters
+     * @return \Omnipay\PayPal\Message\RestCreateSubscriptionRequest
+     */
     public function createSubscription(array $parameters = array())
     {
         return $this->createRequest('\Omnipay\PayPal\Message\RestCreateSubscriptionRequest', $parameters);
     }
 
-    // TODO: Execute an agreement
+    /**
+     * Complete (execute) a subscription.
+     *
+     * Use this call to execute an agreement after the buyer approves it.
+     *
+     * @link https://developer.paypal.com/docs/api/#execute-an-agreement
+     * @param array $parameters
+     * @return \Omnipay\PayPal\Message\RestCompleteSubscriptionRequest
+     */
+    public function completeSubscription(array $parameters = array())
+    {
+        return $this->createRequest('\Omnipay\PayPal\Message\RestCompleteSubscriptionRequest', $parameters);
+    }
+
     // TODO: Update an agreement
     // TODO: Retrieve an agreement
     // TODO: Suspend an agreement

--- a/src/RestGateway.php
+++ b/src/RestGateway.php
@@ -571,6 +571,20 @@ class RestGateway extends AbstractGateway
     }
 
     /**
+     * Cancel a subscription.
+     *
+     * Use this call to cancel an agreement.
+     *
+     * @link https://developer.paypal.com/docs/api/#cancel-an-agreement
+     * @param array $parameters
+     * @return \Omnipay\PayPal\Message\RestCancelSubscriptionRequest
+     */
+    public function cancelSubscription(array $parameters = array())
+    {
+        return $this->createRequest('\Omnipay\PayPal\Message\RestCancelSubscriptionRequest', $parameters);
+    }
+
+    /**
      * Search for transactions.
      *
      * Use this call to search for the transactions within a billing agreement.
@@ -594,7 +608,6 @@ class RestGateway extends AbstractGateway
     // TODO: Retrieve an agreement
     // TODO: Suspend an agreement
     // TODO: Reactivate an agreement
-    // TODO: Cancel an agreement
     // TODO: Set outstanding agreement amounts
     // TODO: Bill outstanding agreement amounts
 }

--- a/src/RestGateway.php
+++ b/src/RestGateway.php
@@ -154,6 +154,10 @@ class RestGateway extends AbstractGateway
     const BILLING_PLAN_FREQUENCY_WEEK   = 'WEEK';
     const BILLING_PLAN_FREQUENCY_MONTH  = 'MONTH';
     const BILLING_PLAN_FREQUENCY_YEAR   = 'YEAR';
+    const BILLING_PLAN_STATE_CREATED    = 'CREATED';
+    const BILLING_PLAN_STATE_ACTIVE     = 'ACTIVE';
+    const BILLING_PLAN_STATE_INACTIVE   = 'INACTIVE';
+    const BILLING_PLAN_STATE_DELETED    = 'DELETED';
     const PAYMENT_TRIAL                 = 'TRIAL';
     const PAYMENT_REGULAR               = 'REGULAR';
 
@@ -522,7 +526,21 @@ class RestGateway extends AbstractGateway
         return $this->createRequest('\Omnipay\PayPal\Message\RestCreatePlanRequest', $parameters);
     }
 
-    // TODO: Update a plan (required to set a plan active)
+    /**
+     * Update a billing plan.
+     *
+     * You can update the information for an existing billing plan. The state of a plan
+     * must be active before a billing agreement is created.
+     *
+     * @link https://developer.paypal.com/docs/api/#update-a-plan
+     * @param array $parameters
+     * @return \Omnipay\PayPal\Message\RestUpdatePlanRequest
+     */
+    public function updatePlan(array $parameters = array())
+    {
+        return $this->createRequest('\Omnipay\PayPal\Message\RestUpdatePlanRequest', $parameters);
+    }
+
     // TODO: Retrieve a plan
     // TODO: List plans
 

--- a/src/RestGateway.php
+++ b/src/RestGateway.php
@@ -572,12 +572,31 @@ class RestGateway extends AbstractGateway
         return $this->createRequest('\Omnipay\PayPal\Message\RestCompleteSubscriptionRequest', $parameters);
     }
 
+    /**
+     * Search for transactions.
+     *
+     * Use this call to search for the transactions within a billing agreement.
+     * Note that this is not a generic transaction search function -- for that
+     * see RestListPurchaseRequest.  It only searches for transactions within
+     * a billing agreement.
+     *
+     * This should be used on a regular basis to determine the success / failure
+     * state of transactions on active billing agreements.
+     *
+     * @link https://developer.paypal.com/docs/api/#search-for-transactions
+     * @param array $parameters
+     * @return \Omnipay\PayPal\Message\RestCompleteSubscriptionRequest
+     */
+    public function searchTransaction(array $parameters = array())
+    {
+        return $this->createRequest('\Omnipay\PayPal\Message\RestSearchTransactionRequest', $parameters);
+    }
+
     // TODO: Update an agreement
     // TODO: Retrieve an agreement
     // TODO: Suspend an agreement
     // TODO: Reactivate an agreement
     // TODO: Cancel an agreement
-    // TODO: Search for transactions
     // TODO: Set outstanding agreement amounts
     // TODO: Bill outstanding agreement amounts
 }

--- a/src/RestGateway.php
+++ b/src/RestGateway.php
@@ -132,8 +132,6 @@ use Omnipay\PayPal\Message\RefundRequest;
  * of those transactions on the "My recent activity" list under the My Account
  * tab.
  *
- * TODO: Billing Plans and Agreements -- set up recurring payments.
- *
  * @link https://developer.paypal.com/docs/api/
  * @link https://devtools-paypal.com/integrationwizard/
  * @link http://paypal.github.io/sdk/

--- a/src/RestGateway.php
+++ b/src/RestGateway.php
@@ -585,6 +585,34 @@ class RestGateway extends AbstractGateway
     }
 
     /**
+     * Suspend a subscription.
+     *
+     * Use this call to suspend an agreement.
+     *
+     * @link https://developer.paypal.com/docs/api/#suspend-an-agreement
+     * @param array $parameters
+     * @return \Omnipay\PayPal\Message\RestSuspendSubscriptionRequest
+     */
+    public function suspendSubscription(array $parameters = array())
+    {
+        return $this->createRequest('\Omnipay\PayPal\Message\RestSuspendSubscriptionRequest', $parameters);
+    }
+
+    /**
+     * Reactivate a suspended subscription.
+     *
+     * Use this call to reactivate or un-suspend an agreement.
+     *
+     * @link https://developer.paypal.com/docs/api/#reactivate-an-agreement
+     * @param array $parameters
+     * @return \Omnipay\PayPal\Message\RestReactivateSubscriptionRequest
+     */
+    public function reactivateSubscription(array $parameters = array())
+    {
+        return $this->createRequest('\Omnipay\PayPal\Message\RestReactivateSubscriptionRequest', $parameters);
+    }
+
+    /**
      * Search for transactions.
      *
      * Use this call to search for the transactions within a billing agreement.
@@ -606,8 +634,6 @@ class RestGateway extends AbstractGateway
 
     // TODO: Update an agreement
     // TODO: Retrieve an agreement
-    // TODO: Suspend an agreement
-    // TODO: Reactivate an agreement
     // TODO: Set outstanding agreement amounts
     // TODO: Bill outstanding agreement amounts
 }

--- a/src/RestGateway.php
+++ b/src/RestGateway.php
@@ -146,6 +146,15 @@ use Omnipay\PayPal\Message\RefundRequest;
  */
 class RestGateway extends AbstractGateway
 {
+
+    // Constants used in plan creation
+    const BILLING_PLAN_TYPE_FIXED       = 'FIXED';
+    const BILLING_PLAN_TYPE_INFINITE    = 'INFINITE';
+    const BILLING_PLAN_FREQUENCY_DAY    = 'DAY';
+    const BILLING_PLAN_FREQUENCY_WEEK   = 'WEEK';
+    const BILLING_PLAN_FREQUENCY_MONTH  = 'MONTH';
+    const BILLING_PLAN_FREQUENCY_YEAR   = 'YEAR';
+
     public function getName()
     {
         return 'PayPal REST';
@@ -487,4 +496,27 @@ class RestGateway extends AbstractGateway
     {
         return $this->createRequest('\Omnipay\PayPal\Message\RestDeleteCardRequest', $parameters);
     }
+
+    //
+    // Billing Plans and Agreements -- Set up recurring payments.
+    // @link https://developer.paypal.com/docs/api/#billing-plans-and-agreements
+    //
+    public function createPlan(array $parameters = array())
+    {
+        return $this->createRequest('\Omnipay\PayPal\Message\RestCreatePlanRequest', $parameters);
+    }
+
+    // TODO: Update a plan (required to set a plan active)
+    // TODO: Retrieve a plan
+    // TODO: List plans
+    // TODO: Create an agreement
+    // TODO: Execute an agreement
+    // TODO: Update an agreement
+    // TODO: Retrieve an agreement
+    // TODO: Suspend an agreement
+    // TODO: Reactivate an agreement
+    // TODO: Cancel an agreement
+    // TODO: Search for transactions
+    // TODO: Set outstanding agreement amounts
+    // TODO: Bill outstanding agreement amounts
 }

--- a/tests/Message/RestCancelSubscriptionRequestTest.php
+++ b/tests/Message/RestCancelSubscriptionRequestTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Omnipay\PayPal\Message;
+
+use Omnipay\Tests\TestCase;
+use Omnipay\PayPal\RestGateway;
+
+class RestCancelSubscriptionRequestTest extends TestCase
+{
+    /** @var \Omnipay\PayPal\Message\RestCancelSubscriptionRequest */
+    private $request;
+
+    public function setUp()
+    {
+        $client = $this->getHttpClient();
+        $request = $this->getHttpRequest();
+        $this->request = new RestCancelSubscriptionRequest($client, $request);
+
+        $this->request->initialize(array(
+            'transactionReference'  => 'ABC-123',
+            'description'           => 'Cancel this subscription',
+        ));
+    }
+
+    public function testGetData()
+    {
+        $data = $this->request->getData();
+        $this->assertEquals('Cancel this subscription', $data['note']);
+    }
+}

--- a/tests/Message/RestCompleteSubscriptionRequestTest.php
+++ b/tests/Message/RestCompleteSubscriptionRequestTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Omnipay\PayPal\Message;
+
+use Omnipay\Tests\TestCase;
+use Omnipay\PayPal\RestGateway;
+
+class RestCompleteSubscriptionRequestTest extends TestCase
+{
+    /** @var \Omnipay\PayPal\Message\RestCompleteSubscriptionRequest */
+    private $request;
+
+    public function setUp()
+    {
+        $client = $this->getHttpClient();
+        $request = $this->getHttpRequest();
+        $this->request = new RestCompleteSubscriptionRequest($client, $request);
+
+        $this->request->initialize(array(
+            'transactionReference'  => 'ABC-123',
+        ));
+    }
+
+    public function testGetData()
+    {
+        $data = $this->request->getData();
+        $this->assertEquals(array(), $data);
+    }
+}

--- a/tests/Message/RestCreatePlanRequestTest.php
+++ b/tests/Message/RestCreatePlanRequestTest.php
@@ -3,10 +3,11 @@
 namespace Omnipay\PayPal\Message;
 
 use Omnipay\Tests\TestCase;
+use Omnipay\PayPal\RestGateway;
 
 class RestCreatePlanRequestTest extends TestCase
 {
-    /** @var \Omnipay\PayPal\Message\RestFetchTransactionRequest */
+    /** @var \Omnipay\PayPal\Message\RestCreatePlanRequest */
     private $request;
 
     public function setUp()
@@ -17,12 +18,13 @@ class RestCreatePlanRequestTest extends TestCase
 
         $this->request->initialize(array(
             'name'                  => 'Super Duper Billing Plan',
-            'type'                  => \Omnipay\PayPal\RestGateway::BILLING_PLAN_TYPE_FIXED,
+            'description'           => 'Test Billing Plan',
+            'type'                  => RestGateway::BILLING_PLAN_TYPE_FIXED,
             'paymentDefinitions'    => array(
                 array(
                     'name'                  => 'Monthly Payments',
-                    'type'                  => \Omnipay\PayPal\RestGateway::PAYMENT_REGULAR,
-                    'frequency'             => \Omnipay\PayPal\RestGateway::BILLING_PLAN_FREQUENCY_MONTH,
+                    'type'                  => RestGateway::PAYMENT_REGULAR,
+                    'frequency'             => RestGateway::BILLING_PLAN_FREQUENCY_MONTH,
                     'frequency_interval'    => 1,
 	                'cycles'                => 12,
 	                'amount'                => array(
@@ -31,7 +33,9 @@ class RestCreatePlanRequestTest extends TestCase
                     )
                 )
             ),
-            'merchantPrefrences'    => array(),
+            'merchantPreferences'    => array(
+                'name'  => 'asdf',
+            ),
         ));
     }
 
@@ -39,13 +43,7 @@ class RestCreatePlanRequestTest extends TestCase
     {
         $data = $this->request->getData();
         $this->assertEquals('Super Duper Billing Plan', $data['name']);
-        $this->request->setTransactionReference('ABC-123');
-        $this->assertStringEndsWith('/payments/sale/ABC-123', $this->request->getEndpoint());
-    }
-
-    public function testGetEndpoint()
-    {
-        $endpoint = $this->request->getEndpoint();
-        $this->assertStringEndsWith('/payments/billing-plans', $endpoint);
+        $this->assertEquals(RestGateway::BILLING_PLAN_TYPE_FIXED, $data['type']);
+        $this->assertEquals('Monthly Payments', $data['payment_definitions'][0]['name']);
     }
 }

--- a/tests/Message/RestCreatePlanRequestTest.php
+++ b/tests/Message/RestCreatePlanRequestTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Omnipay\PayPal\Message;
+
+use Omnipay\Tests\TestCase;
+
+class RestCreatePlanRequestTest extends TestCase
+{
+    /** @var \Omnipay\PayPal\Message\RestFetchTransactionRequest */
+    private $request;
+
+    public function setUp()
+    {
+        $client = $this->getHttpClient();
+        $request = $this->getHttpRequest();
+        $this->request = new RestCreatePlanRequest($client, $request);
+
+        $this->request->initialize(array(
+            'name'                  => 'Super Duper Billing Plan',
+            'type'                  => \Omnipay\PayPal\RestGateway::BILLING_PLAN_TYPE_FIXED,
+            'paymentDefinitions'    => array(
+                array(
+                    'name'                  => 'Monthly Payments',
+                    'type'                  => \Omnipay\PayPal\RestGateway::PAYMENT_REGULAR,
+                    'frequency'             => \Omnipay\PayPal\RestGateway::BILLING_PLAN_FREQUENCY_MONTH,
+                    'frequency_interval'    => 1,
+	                'cycles'                => 12,
+	                'amount'                => array(
+                        'value'     => 10.00,
+                        'currency'  => 'USD',
+                    )
+                )
+            ),
+            'merchantPrefrences'    => array(),
+        ));
+    }
+
+    public function testGetData()
+    {
+        $data = $this->request->getData();
+        $this->assertEquals('Super Duper Billing Plan', $data['name']);
+        $this->request->setTransactionReference('ABC-123');
+        $this->assertStringEndsWith('/payments/sale/ABC-123', $this->request->getEndpoint());
+    }
+
+    public function testGetEndpoint()
+    {
+        $endpoint = $this->request->getEndpoint();
+        $this->assertStringEndsWith('/payments/billing-plans', $endpoint);
+    }
+}

--- a/tests/Message/RestCreateSubscriptionRequestTest.php
+++ b/tests/Message/RestCreateSubscriptionRequestTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Omnipay\PayPal\Message;
+
+use Omnipay\Tests\TestCase;
+use Omnipay\PayPal\RestGateway;
+
+class RestCreateSubscriptionRequestTest extends TestCase
+{
+    /** @var \Omnipay\PayPal\Message\RestCreateSubscriptionRequest */
+    private $request;
+
+    public function setUp()
+    {
+        $client = $this->getHttpClient();
+        $request = $this->getHttpRequest();
+        $this->request = new RestCreateSubscriptionRequest($client, $request);
+
+        $this->request->initialize(array(
+            'name'                  => 'Test Subscription',
+            'description'           => 'Test Billing Subscription',
+            'startDate'             => new \DateTime(),
+            'planId'                => 'ABC-123',
+            'payerDetails'          => array(
+                'payment_method'    => 'paypal',
+            ),
+        ));
+    }
+
+    public function testGetData()
+    {
+        $data = $this->request->getData();
+        $this->assertEquals('Test Subscription', $data['name']);
+        $this->assertEquals('Test Billing Subscription', $data['description']);
+        $this->assertEquals('ABC-123', $data['plan']['id']);
+        $this->assertEquals('paypal', $data['payer']['payment_method']);
+    }
+}

--- a/tests/Message/RestFetchTransactionRequestTest.php
+++ b/tests/Message/RestFetchTransactionRequestTest.php
@@ -16,6 +16,13 @@ class RestFetchTransactionRequestTest extends TestCase
         $this->request = new RestFetchTransactionRequest($client, $request);
     }
 
+    public function testGetData()
+    {
+        $this->request->setTransactionReference('ABC-123');
+        $data = $this->request->getData();
+        $this->assertEquals(array(), $data);
+    }
+
     public function testEndpoint()
     {
         $this->request->setTransactionReference('ABC-123');

--- a/tests/Message/RestReactivateSubscriptionRequestTest.php
+++ b/tests/Message/RestReactivateSubscriptionRequestTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Omnipay\PayPal\Message;
+
+use Omnipay\Tests\TestCase;
+use Omnipay\PayPal\RestGateway;
+
+class RestReactivateSubscriptionRequestTest extends TestCase
+{
+    /** @var \Omnipay\PayPal\Message\RestReactivateSubscriptionRequest */
+    private $request;
+
+    public function setUp()
+    {
+        $client = $this->getHttpClient();
+        $request = $this->getHttpRequest();
+        $this->request = new RestReactivateSubscriptionRequest($client, $request);
+
+        $this->request->initialize(array(
+            'transactionReference'  => 'ABC-123',
+            'description'           => 'Reactivate this subscription',
+        ));
+    }
+
+    public function testGetData()
+    {
+        $data = $this->request->getData();
+        $this->assertEquals('Reactivate this subscription', $data['note']);
+    }
+}

--- a/tests/Message/RestSearchTransactionRequestTest.php
+++ b/tests/Message/RestSearchTransactionRequestTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Omnipay\PayPal\Message;
+
+use Omnipay\Tests\TestCase;
+use Omnipay\PayPal\RestGateway;
+
+class RestSearchTransactionRequestTest extends TestCase
+{
+    /** @var \Omnipay\PayPal\Message\RestSearchTransactionRequest */
+    private $request;
+
+    public function setUp()
+    {
+        $client = $this->getHttpClient();
+        $request = $this->getHttpRequest();
+        $this->request = new RestSearchTransactionRequest($client, $request);
+
+        $this->request->initialize(array(
+            'agreementId'       => 'ABC-123',
+            'startDate'         => '2015-09-01',
+            'endDate'           => '2015-09-30',
+        ));
+    }
+
+    public function testGetData()
+    {
+        $data = $this->request->getData();
+        $this->assertEquals('2015-09-01', $data['start_date']);
+        $this->assertEquals('2015-09-30', $data['end_date']);
+    }
+
+    public function testEndpoint()
+    {
+        $this->assertStringEndsWith('/payments/billing-agreements/ABC-123/transactions', $this->request->getEndpoint());
+    }
+}

--- a/tests/Message/RestSuspendSubscriptionRequestTest.php
+++ b/tests/Message/RestSuspendSubscriptionRequestTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Omnipay\PayPal\Message;
+
+use Omnipay\Tests\TestCase;
+use Omnipay\PayPal\RestGateway;
+
+class RestSuspendSubscriptionRequestTest extends TestCase
+{
+    /** @var \Omnipay\PayPal\Message\RestSuspendSubscriptionRequest */
+    private $request;
+
+    public function setUp()
+    {
+        $client = $this->getHttpClient();
+        $request = $this->getHttpRequest();
+        $this->request = new RestSuspendSubscriptionRequest($client, $request);
+
+        $this->request->initialize(array(
+            'transactionReference'  => 'ABC-123',
+            'description'           => 'Suspend this subscription',
+        ));
+    }
+
+    public function testGetData()
+    {
+        $data = $this->request->getData();
+        $this->assertEquals('Suspend this subscription', $data['note']);
+    }
+}

--- a/tests/Message/RestUpdatePlanRequestTest.php
+++ b/tests/Message/RestUpdatePlanRequestTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Omnipay\PayPal\Message;
+
+use Omnipay\Tests\TestCase;
+use Omnipay\PayPal\RestGateway;
+
+class RestUpdatePlanRequestTest extends TestCase
+{
+    /** @var \Omnipay\PayPal\Message\RestUpdatePlanRequest */
+    private $request;
+
+    public function setUp()
+    {
+        $client = $this->getHttpClient();
+        $request = $this->getHttpRequest();
+        $this->request = new RestUpdatePlanRequest($client, $request);
+
+        $this->request->initialize(array(
+            'transactionReference'  => 'ABC-123',
+            'state'                 => 'ACTIVE',
+        ));
+    }
+
+    public function testGetData()
+    {
+        $data = $this->request->getData();
+        $this->assertEquals('/', $data[0]['path']);
+        $this->assertEquals('ACTIVE', $data[0]['value']['state']);
+    }
+}

--- a/tests/Mock/RestExecuteSubscriptionSuccess.txt
+++ b/tests/Mock/RestExecuteSubscriptionSuccess.txt
@@ -1,0 +1,20 @@
+HTTP/1.1 200 OK
+Server: Apache-Coyote/1.1
+PROXY_SERVER_INFO: host=slcsbjava2.slc.paypal.com;threadId=76018
+Paypal-Debug-Id: 965491cb1a1e5
+SERVER_INFO: paymentsplatformserv:v1.payments.sale&CalThreadId=129&TopLevelTxnStartTime=14701c36ef9&Host=slcsbjm3.slc.paypal.com&pid=15797
+CORRELATION-ID: 965491cb1a1e5
+Content-Language: *
+Date: Fri, 04 Jul 2014 14:24:52 GMT
+Content-Type: application/json
+
+{
+  "id": "I-0LN988D3JACS",
+  "links": [
+    {
+      "href": "https://api.sandbox.paypal.com/v1/payments/billing-agreements/I-0LN988D3JACS",
+      "rel": "self",
+      "method": "GET"
+    }
+  ]
+}

--- a/tests/Mock/RestGenericSubscriptionSuccess.txt
+++ b/tests/Mock/RestGenericSubscriptionSuccess.txt
@@ -1,0 +1,7 @@
+HTTP/1.1 204 OK
+Server: Apache-Coyote/1.1
+PROXY_SERVER_INFO: host=slcsbjava3.slc.paypal.com;threadId=3205
+Paypal-Debug-Id: 217a9ddefd384
+SERVER_INFO: identitysecuretokenserv:v1.oauth2.token&CalThreadId=91&TopLevelTxnStartTime=146fbfe679a&Host=slcsbidensectoken502.slc.paypal.com&pid=29059
+CORRELATION-ID: 217a9ddefd384
+Date: Thu, 03 Jul 2014 11:31:32 GMT

--- a/tests/RestGatewayTest.php
+++ b/tests/RestGatewayTest.php
@@ -7,6 +7,15 @@ use Omnipay\Common\CreditCard;
 
 class RestGatewayTest extends GatewayTestCase
 {
+    /** @var RestGateway */
+    public $gateway;
+
+    /** @var array */
+    public $options;
+
+    /** @var array */
+    public $subscription_options;
+
     public function setUp()
     {
         parent::setUp();
@@ -25,6 +34,11 @@ class RestGatewayTest extends GatewayTestCase
                 'expiryYear' => '2016',
                 'cvv' => '123',
             )),
+        );
+
+        $this->subscription_options = array(
+            'transactionReference'  => 'ABC-1234',
+            'description'           => 'Description goes here',
         );
     }
 
@@ -113,4 +127,39 @@ class RestGatewayTest extends GatewayTestCase
         $this->assertNull($response->getMessage());
     }
 
+    // Incomplete generic tests for subscription payments
+
+    public function testCompleteSubscription()
+    {
+        $this->setMockHttpResponse('RestExecuteSubscriptionSuccess.txt');
+        $response = $this->gateway->completeSubscription($this->subscription_options)->send();
+        $this->assertTrue($response->isSuccessful());
+        $this->assertNull($response->getMessage());
+
+        $this->assertEquals('I-0LN988D3JACS', $response->getTransactionReference());
+    }
+
+    public function testCancelSubscription()
+    {
+        $this->setMockHttpResponse('RestGenericSubscriptionSuccess.txt');
+        $response = $this->gateway->cancelSubscription($this->subscription_options)->send();
+        $this->assertTrue($response->isSuccessful());
+        $this->assertNull($response->getMessage());
+    }
+
+    public function testSuspendSubscription()
+    {
+        $this->setMockHttpResponse('RestGenericSubscriptionSuccess.txt');
+        $response = $this->gateway->suspendSubscription($this->subscription_options)->send();
+        $this->assertTrue($response->isSuccessful());
+        $this->assertNull($response->getMessage());
+    }
+
+    public function testReactivateSubscription()
+    {
+        $this->setMockHttpResponse('RestGenericSubscriptionSuccess.txt');
+        $response = $this->gateway->reactivateSubscription($this->subscription_options)->send();
+        $this->assertTrue($response->isSuccessful());
+        $this->assertNull($response->getMessage());
+    }
 }


### PR DESCRIPTION
This PR implements billing plans and agreements (subscriptions) in the PayPal REST gateway.  Although Omnipay does not in the general case implement subscriptions, preferring to use card tokens to allow subscriptions to be managed by the application, in the case of PayPal payments from a customer's PayPal account subscriptions cannot be implemented that way.

This is not complete yet -- there are a few functions missing such as Update/Cancel/Suspend/Reactivate agreement, but I have chosen to push this PR now to create an API definition for the basic functions required to create working subscriptions.

The function names chosen are identical to those in the Stripe gateway, which also handles subscriptions, although the parameter structure is necessarily different.

All functions have tests and documentation.