### PR TITLE
Add support for Instant Update API Callback

### DIFF
--- a/src/Message/ExpressAuthorizeRequest.php
+++ b/src/Message/ExpressAuthorizeRequest.php
@@ -114,8 +114,7 @@ class ExpressAuthorizeRequest extends AbstractRequest
             $shippingOptions = $this->getShippingOptions();
 
             if (!empty($shippingOptions)) {
-                foreach ($shippingOptions as $shipping) {
-                    $index     = $shipping['index'];
+                foreach ($shippingOptions as $index => $shipping) {
                     $name      = $shipping['name'];
                     $isDefault = $shipping['isDefault'];
                     $amount    = $shipping['amount'];

--- a/src/Message/ExpressAuthorizeRequest.php
+++ b/src/Message/ExpressAuthorizeRequest.php
@@ -76,7 +76,7 @@ class ExpressAuthorizeRequest extends AbstractRequest
         $callback = $this->getCallback();
 
         if (!empty($callback)) {
-            $data['CALLBACK']        = $callback;
+            $data['CALLBACK'] = $callback;
             // callback timeout MUST be included and > 0
             $timeout = $this->getCallbackTimeout();
 
@@ -87,13 +87,13 @@ class ExpressAuthorizeRequest extends AbstractRequest
 
             if (!empty($shippingOptions)) {
                 foreach ($shippingOptions as $index => $shipping) {
-                    $name      = $shipping['name'];
+                    $name = $shipping['name'];
                     $isDefault = $shipping['isDefault'];
-                    $amount    = $shipping['amount'];
-                    $label     = isset($shipping['label']) ? $shipping['label'] : '';
+                    $amount = $shipping['amount'];
+                    $label = isset($shipping['label']) ? $shipping['label'] : '';
 
-                    $data['L_SHIPPINGOPTIONNAME' . $index]      = $name;
-                    $data['L_SHIPPINGOPTIONAMOUNT' . $index]    = number_format($amount, 2);
+                    $data['L_SHIPPINGOPTIONNAME' . $index] = $name;
+                    $data['L_SHIPPINGOPTIONAMOUNT' . $index] = number_format($amount, 2);
                     $data['L_SHIPPINGOPTIONISDEFAULT' . $index] = $isDefault ? '1' : '0';
 
                     if (!empty($label)) {

--- a/src/Message/ExpressAuthorizeRequest.php
+++ b/src/Message/ExpressAuthorizeRequest.php
@@ -32,8 +32,7 @@ class ExpressAuthorizeRequest extends AbstractRequest
 
     /**
      * Multi-dimensional array of shipping options, containing:
-     *  - index, name, amount, isDefault, label
-     * index is 0-based as per PayPal's docs. label is optional
+     *  name, amount, isDefault, and an optional label
      *
      * @param array $data
      */

--- a/src/Message/ExpressAuthorizeRequest.php
+++ b/src/Message/ExpressAuthorizeRequest.php
@@ -31,33 +31,6 @@ class ExpressAuthorizeRequest extends AbstractRequest
     }
 
     /**
-     * @param int    $index
-     * @param string $name
-     * @param float  $amount
-     * @param bool   $isDefault
-     * @param string $label
-     */
-    public function setShippingOption($index, $name, $amount, $isDefault, $label = null)
-    {
-        $data['L_SHIPPINGOPTIONNAME' . $index] = $name;
-        $data['L_SHIPPINGOPTIONAMOUNT' . $index] = number_format($amount, 2);
-        $data['L_SHIPPINGOPTIONISDEFAULT' . $index] = $isDefault ? '1' : '0';
-
-        if (!is_null($label)) {
-            $data['L_SHIPPINGOPTIONLABEL' . $index] = $name;
-        }
-
-        $currentShippingOptions = $this->getParameter('shippingOptions');
-        if (empty($currentShippingOptions)) {
-            $currentShippingOptions = array();
-        }
-
-        $currentShippingOptions[$index] = $data;
-
-        $this->setParameter('shippingOptions', $currentShippingOptions);
-    }
-
-    /**
      * Multi-dimensional array of shipping options, containing:
      *  - index, name, amount, isDefault, label
      * index is 0-based as per PayPal's docs. label is optional

--- a/src/Message/ExpressAuthorizeRequest.php
+++ b/src/Message/ExpressAuthorizeRequest.php
@@ -2,6 +2,8 @@
 
 namespace Omnipay\PayPal\Message;
 
+use Omnipay\Common\Exception\InvalidRequestException;
+
 /**
  * PayPal Express Authorize Request
  */
@@ -46,9 +48,25 @@ class ExpressAuthorizeRequest extends AbstractRequest
         return $this->getParameter('shippingOptions');
     }
 
+    protected function validateCallback()
+    {
+        $callback = $this->getCallback();
+
+        if (!empty($callback)) {
+            $shippingOptions = $this->getShippingOptions();
+
+            if (empty($shippingOptions)) {
+                throw new InvalidRequestException(
+                    'When setting a callback for the Instant Update API you must set shipping options'
+                );
+            }
+        }
+    }
+
     public function getData()
     {
         $this->validate('amount', 'returnUrl', 'cancelUrl');
+        $this->validateCallback();
 
         $data = $this->getBaseData();
         $data['METHOD'] = 'SetExpressCheckout';

--- a/src/Support/InstantUpdateApi/ShippingOption.php
+++ b/src/Support/InstantUpdateApi/ShippingOption.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Omnipay\PayPal\Support\InstantUpdateApi;
+
+class ShippingOption
+{
+    /** @var string */
+    private $name;
+
+    /** @var float */
+    private $amount;
+
+    /** @var bool */
+    private $isDefault;
+
+    /** @var string */
+    private $label;
+
+    /**
+     * @param string $name      L_SHIPPINGOPTIONNAME0
+     * @param float  $amount    L_SHIPPINGOPTIONAMOUNT0
+     * @param bool   $isDefault L_SHIPPINGOPTIONISDEFAULT0
+     * @param string $label     L_SHIPPINGOPTIONLABEL0
+     */
+    public function __construct($name, $amount, $isDefault = false, $label = null)
+    {
+        $this->name      = $name;
+        $this->amount    = $amount;
+        $this->isDefault = $isDefault;
+        $this->label     = $label;
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasLabel()
+    {
+        return !is_null($this->label);
+    }
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * @return float
+     */
+    public function getAmount()
+    {
+        return $this->amount;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function isDefault()
+    {
+        return $this->isDefault;
+    }
+
+    /**
+     * @return string
+     */
+    public function getLabel()
+    {
+        return $this->label;
+    }
+}

--- a/tests/Message/ExpressAuthorizeRequestTest.php
+++ b/tests/Message/ExpressAuthorizeRequestTest.php
@@ -3,6 +3,7 @@
 namespace Omnipay\PayPal\Message;
 
 use Omnipay\Common\CreditCard;
+use Omnipay\PayPal\Support\InstantUpdateApi\ShippingOption;
 use Omnipay\Tests\TestCase;
 
 class ExpressAuthorizeRequestTest extends TestCase
@@ -233,23 +234,9 @@ class ExpressAuthorizeRequestTest extends TestCase
         );
 
         $shippingOptions = array(
-            array(
-                'name'      => 'First Class',
-                'label'     => '1-2 days',
-                'amount'    => 1.20,
-                'isDefault' => true,
-            ),
-            array(
-                'name'      => 'Second Class',
-                'label'     => '3-5 days',
-                'amount'    => 0.70,
-                'isDefault' => false,
-            ),
-            array(
-                'name'      => 'International',
-                'amount'    => 3.50,
-                'isDefault' => false,
-            )
+            new ShippingOption('First Class', 1.20, true, '1-2 days'),
+            new ShippingOption('Second Class', 0.70, false, '3-5 days'),
+            new ShippingOption('International', 3.50),
         );
 
         // with a default callback timeout

--- a/tests/Message/ExpressAuthorizeRequestTest.php
+++ b/tests/Message/ExpressAuthorizeRequestTest.php
@@ -275,6 +275,42 @@ class ExpressAuthorizeRequestTest extends TestCase
         $this->assertSame(10, $data['CALLBACKTIMEOUT']);
     }
 
+    public function testDataWithCallbackAndNoDefaultShippingOption()
+    {
+        $baseData = array(
+            'amount' => '10.00',
+            'currency' => 'AUD',
+            'transactionId' => '111',
+            'description' => 'Order Description',
+            'returnUrl' => 'https://www.example.com/return',
+            'cancelUrl' => 'https://www.example.com/cancel',
+            'subject' => 'demo@example.com',
+            'headerImageUrl' => 'https://www.example.com/header.jpg',
+            'allowNote' => 0,
+            'addressOverride' => 0,
+            'brandName' => 'Dunder Mifflin Paper Company, Incy.',
+        );
+
+        $shippingOptions = array(
+            new ShippingOption('First Class', 1.20, false, '1-2 days'),
+            new ShippingOption('Second Class', 0.70, false, '3-5 days'),
+            new ShippingOption('International', 3.50),
+        );
+
+        // with a default callback timeout
+        $this->request->initialize(array_merge($baseData, array(
+            'callback' => 'https://www.example.com/calculate-shipping',
+            'shippingOptions' => $shippingOptions,
+        )));
+
+        $this->setExpectedException(
+            '\Omnipay\Common\Exception\InvalidRequestException',
+            'One of the supplied shipping options must be set as default'
+        );
+
+        $this->request->getData();
+    }
+
     public function testNoAmount()
     {
         $baseData = array(// nothing here - should cause a certain exception

--- a/tests/Message/ExpressAuthorizeRequestTest.php
+++ b/tests/Message/ExpressAuthorizeRequestTest.php
@@ -237,21 +237,18 @@ class ExpressAuthorizeRequestTest extends TestCase
             'callback' => 'https://www.example.com/calculate-shipping',
             'shippingOptions' => array(
                 array(
-                    'index' => 0,
                     'name' => 'First Class',
                     'label' => '1-2 days',
                     'amount' => 1.20,
                     'isDefault' => true,
                 ),
                 array(
-                    'index' => 1,
                     'name' => 'Second Class',
                     'label' => '3-5 days',
                     'amount' => 0.70,
                     'isDefault' => false,
                 ),
                 array(
-                    'index' => 2,
                     'name' => 'International',
                     'amount' => 3.50,
                     'isDefault' => false,


### PR DESCRIPTION
Add support for PayPal's Instant Update API shipping costs calculator

* it requires you to send PayPal a callback URL
* if you send a callback URL, you must also specify its timeout and default shipping options
* on line 115 where we check for `if (!empty($shippingOptions))` it arguably should throw an `InvalidArgumentException` or similar - the rest of the library doesn't do this, so I have left it as is to be consistent with the current behaviour
* included a test as per the contribution guidelines, please let me know if more is required