### PR TITLE
Update test to check for empty object instead of just empty

### DIFF
--- a/tests/RestGatewayTest.php
+++ b/tests/RestGatewayTest.php
@@ -138,7 +138,10 @@ class RestGatewayTest extends GatewayTestCase
         $endPoint = $request->getEndpoint();
         $this->assertSame('https://api.paypal.com/v1/payments/sale/abc123/refund', $endPoint);
         $data = $request->getData();
-        $this->assertEmpty($data);
+
+        // we're expecting an empty object here
+        $json = json_encode($data);
+        $this->assertEquals('{}', $json);
     }
 
     public function testFetchTransaction()


### PR DESCRIPTION
 - changes in 2a2191f705b43986b0647a2d0143c3052745199a fixed
   issue by returning '{}' which is what PayPal expects for a refund