### PR TITLE
Fix the failing unit test

### DIFF
--- a/tests/RestGatewayTest.php
+++ b/tests/RestGatewayTest.php
@@ -138,7 +138,8 @@ class RestGatewayTest extends GatewayTestCase
         $endPoint = $request->getEndpoint();
         $this->assertSame('https://api.paypal.com/v1/payments/sale/abc123/refund', $endPoint);
         $data = $request->getData();
-        $this->assertEmpty($data);
+        $arr = (array)$data;
+        $this->assertEmpty($arr);
     }
 
     public function testFetchTransaction()


### PR DESCRIPTION
This fixes a unit test that was failing due to the fact that RestRefundRequest now contains an empty stdClass object for a full refund instead of an empty array.