### PR TITLE
Add support for TLS v1.2

### DIFF
--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -315,7 +315,7 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
     {
         $url = $this->getEndpoint().'?'.http_build_query($data, '', '&');
         $httpRequest = $this->httpClient->get($url);
-        $httpRequest->getCurlOptions()->set(CURLOPT_SSLVERSION, 6); // CURL_SSLVERSION_TLSv1_2
+        $httpRequest->getCurlOptions()->set(CURLOPT_SSLVERSION, 6); // CURL_SSLVERSION_TLSv1_2 for libcurl < 7.35
         $httpResponse = $httpRequest->send();
 
         return $this->createResponse($httpResponse->getBody());

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -314,7 +314,9 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
     public function sendData($data)
     {
         $url = $this->getEndpoint().'?'.http_build_query($data, '', '&');
-        $httpResponse = $this->httpClient->get($url)->send();
+        $httpRequest = $this->httpClient->get($url);
+        $httpRequest->getCurlOptions()->set(CURLOPT_SSLVERSION, 6); // CURL_SSLVERSION_TLSv1_2
+        $httpResponse = $httpRequest->send();
 
         return $this->createResponse($httpResponse->getBody());
     }

--- a/src/Message/AbstractRestRequest.php
+++ b/src/Message/AbstractRestRequest.php
@@ -163,6 +163,7 @@ abstract class AbstractRestRequest extends \Omnipay\Common\Message\AbstractReque
         // echo "Data == " . json_encode($data) . "\n";
 
         try {
+            $httpRequest->getCurlOptions()->set(CURLOPT_SSLVERSION, 6); // CURL_SSLVERSION_TLSv1_2 for libcurl < 7.35
             $httpResponse = $httpRequest->send();
             return $this->response = $this->createResponse($httpResponse->json(), $httpResponse->getStatusCode());
         } catch (\Exception $e) {


### PR DESCRIPTION
 for Operating Systems without TLS v1.2 bundled by default (CentOS 6.7 for example)