### PR TITLE
check item class

### DIFF
--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -307,7 +307,7 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
                 $data["L_PAYMENTREQUEST_0_QTY$n"] = $item->getQuantity();
                 $data["L_PAYMENTREQUEST_0_AMT$n"] = $this->formatCurrency($item->getPrice());
                 if ($item instanceof PayPalItem) {
-                    $data["L_PAYMENTREQUEST_0_NUMBER$n"] = $item->getCode();   
+                    $data["L_PAYMENTREQUEST_0_NUMBER$n"] = $item->getCode();
                 }
 
                 $data["PAYMENTREQUEST_0_ITEMAMT"] += $item->getQuantity() * $this->formatCurrency($item->getPrice());

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -6,6 +6,7 @@
 namespace Omnipay\PayPal\Message;
 
 use Omnipay\Common\ItemBag;
+use Omnipay\PayPal\PayPalItem;
 use Omnipay\PayPal\PayPalItemBag;
 
 /**
@@ -305,7 +306,9 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
                 $data["L_PAYMENTREQUEST_0_DESC$n"] = $item->getDescription();
                 $data["L_PAYMENTREQUEST_0_QTY$n"] = $item->getQuantity();
                 $data["L_PAYMENTREQUEST_0_AMT$n"] = $this->formatCurrency($item->getPrice());
-                $data["L_PAYMENTREQUEST_0_NUMBER$n"] = $item->getCode();
+                if ($item instanceof PayPalItem) {
+                    $data["L_PAYMENTREQUEST_0_NUMBER$n"] = $item->getCode();   
+                }
 
                 $data["PAYMENTREQUEST_0_ITEMAMT"] += $item->getQuantity() * $this->formatCurrency($item->getPrice());
             }


### PR DESCRIPTION
Only call `getCode` if the item is a PayPalItem instance.

fix for: 
- https://github.com/thephpleague/omnipay/issues/379
- https://github.com/thephpleague/omnipay-paypal/issues/135