### PR TITLE
Fix the transaction ID retrieval for billing agreements

### DIFF
--- a/src/Message/RestAuthorizeResponse.php
+++ b/src/Message/RestAuthorizeResponse.php
@@ -70,7 +70,7 @@ class RestAuthorizeResponse extends RestResponse implements RedirectResponseInte
 
         // The last element of the URL should be "execute"
         $execute = end($urlParts);
-        if ($execute != 'execute') {
+        if (!in_array($execute, array('execute', 'agreement-execute')) {
             return parent::getTransactionReference();
         }
 

--- a/src/Message/RestAuthorizeResponse.php
+++ b/src/Message/RestAuthorizeResponse.php
@@ -70,7 +70,7 @@ class RestAuthorizeResponse extends RestResponse implements RedirectResponseInte
 
         // The last element of the URL should be "execute"
         $execute = end($urlParts);
-        if (!in_array($execute, array('execute', 'agreement-execute')) {
+        if (!in_array($execute, array('execute', 'agreement-execute'))) {
             return parent::getTransactionReference();
         }
 


### PR DESCRIPTION
The endpoint billing agreements terminates with "agreement-execute" not "execute", therefore the transaction reference was not being returned.

https://developer.paypal.com/docs/api/payments.billing-agreements#agreement_create_response