### PR TITLE
[WIP] 3.0 Upgrade

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 language: php
 
 php:
-  - 5.3
-  - 5.4
-  - 5.5
   - 5.6
   - 7.0
   - 7.1
@@ -15,9 +12,9 @@ env:
 
 matrix:
   include:
-    - php: 5.3
+    - php: 5.6
       env: setup=lowest
-    - php: 5.5
+    - php: 5.6
       env: setup=stable
 
 sudo: false

--- a/composer.json
+++ b/composer.json
@@ -27,14 +27,14 @@
         "psr-4": { "Omnipay\\PayPal\\" : "src/" }
     },
     "require": {
-        "omnipay/common": "~2.0"
+        "omnipay/common": "~3.0"
     },
     "require-dev": {
-        "omnipay/tests": "~2.0"
+        "omnipay/tests": "~3.0"
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "2.3.x-dev"
+            "dev-master": "3.0.x-dev"
         }
     },
     "minimum-stability": "dev"

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -320,11 +320,9 @@ abstract class AbstractRequest extends \League\Omnipay\Common\Message\AbstractRe
 
     public function sendData($data)
     {
-        $httpRequest = $this->httpClient->post($this->getEndpoint(), null, http_build_query($data, '', '&'));
-        $httpRequest->getCurlOptions()->set(CURLOPT_SSLVERSION, 6); // CURL_SSLVERSION_TLSv1_2 for libcurl < 7.35
-        $httpResponse = $httpRequest->send();
+        $httpResponse = $this->httpClient->post($this->getEndpoint(), [], http_build_query($data, '', '&'));
 
-        return $this->createResponse($httpResponse->getBody());
+        return $this->createResponse($httpResponse->getBody()->getContents());
     }
 
     protected function getEndpoint()

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -25,11 +25,11 @@ use Omnipay\PayPal\PayPalItemBag;
  *   Account; it also gives the merchant the flexibility to change payment
  *   processors without having to re-do their technical integration. When using
  *   PayPal Payments Pro (Payflow Edition) using Payflow Gateway integration,
- *   merchants can use Transparent Redirect feature to help manage PCI compliance. 
+ *   merchants can use Transparent Redirect feature to help manage PCI compliance.
  *
  * @link https://developer.paypal.com/docs/classic/products/payflow-gateway/
  * @link https://developer.paypal.com/docs/classic/express-checkout/gs_expresscheckout/
- * @link https://developer.paypal.com/docs/classic/products/ppp-payflow-edition/ 
+ * @link https://developer.paypal.com/docs/classic/products/ppp-payflow-edition/
  * @link https://devtools-paypal.com/integrationwizard/
  * @link http://paypal.github.io/sdk/
  */

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -306,7 +306,7 @@ abstract class AbstractRequest extends \League\Omnipay\Common\Message\AbstractRe
                 $data["L_PAYMENTREQUEST_0_NAME$n"] = $item->getName();
                 $data["L_PAYMENTREQUEST_0_DESC$n"] = $item->getDescription();
                 $data["L_PAYMENTREQUEST_0_QTY$n"] = $item->getQuantity();
-                $amount = new Amount($item->getPrice(), $this->getCurrency());
+                $amount = Amount::fromDecimal($item->getPrice(), $this->getCurrency());
                 $data["L_PAYMENTREQUEST_0_AMT$n"] = $amount->getFormatted();
                 if ($item instanceof PayPalItem) {
                     $data["L_PAYMENTREQUEST_0_NUMBER$n"] = $item->getCode();
@@ -314,7 +314,7 @@ abstract class AbstractRequest extends \League\Omnipay\Common\Message\AbstractRe
 
                 $data["PAYMENTREQUEST_0_ITEMAMT"] += $item->getQuantity() * $amount->getFormatted();
             }
-            $amount = new Amount($data["PAYMENTREQUEST_0_ITEMAMT"], $this->getCurrency());
+            $amount = Amount::fromDecimal($data["PAYMENTREQUEST_0_ITEMAMT"], $this->getCurrency());
             $data["PAYMENTREQUEST_0_ITEMAMT"] = $amount->getFormatted();
         }
 

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -5,6 +5,7 @@
 
 namespace Omnipay\PayPal\Message;
 
+use League\Omnipay\Common\Amount;
 use League\Omnipay\Common\ItemBag;
 use Omnipay\PayPal\PayPalItem;
 use Omnipay\PayPal\PayPalItemBag;
@@ -305,14 +306,16 @@ abstract class AbstractRequest extends \League\Omnipay\Common\Message\AbstractRe
                 $data["L_PAYMENTREQUEST_0_NAME$n"] = $item->getName();
                 $data["L_PAYMENTREQUEST_0_DESC$n"] = $item->getDescription();
                 $data["L_PAYMENTREQUEST_0_QTY$n"] = $item->getQuantity();
-                $data["L_PAYMENTREQUEST_0_AMT$n"] = $this->formatCurrency($item->getPrice());
+                $amount = new Amount($item->getPrice(), $this->getCurrency());
+                $data["L_PAYMENTREQUEST_0_AMT$n"] = $amount->getFormatted();
                 if ($item instanceof PayPalItem) {
                     $data["L_PAYMENTREQUEST_0_NUMBER$n"] = $item->getCode();
                 }
 
-                $data["PAYMENTREQUEST_0_ITEMAMT"] += $item->getQuantity() * $this->formatCurrency($item->getPrice());
+                $data["PAYMENTREQUEST_0_ITEMAMT"] += $item->getQuantity() * $amount->getFormatted();
             }
-            $data["PAYMENTREQUEST_0_ITEMAMT"] = $this->formatCurrency($data["PAYMENTREQUEST_0_ITEMAMT"]);
+            $amount = new Amount($data["PAYMENTREQUEST_0_ITEMAMT"], $this->getCurrency());
+            $data["PAYMENTREQUEST_0_ITEMAMT"] = $amount->getFormatted();
         }
 
         return $data;

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -5,7 +5,7 @@
 
 namespace Omnipay\PayPal\Message;
 
-use Omnipay\Common\ItemBag;
+use League\Omnipay\Common\ItemBag;
 use Omnipay\PayPal\PayPalItem;
 use Omnipay\PayPal\PayPalItemBag;
 
@@ -32,7 +32,7 @@ use Omnipay\PayPal\PayPalItemBag;
  * @link https://devtools-paypal.com/integrationwizard/
  * @link http://paypal.github.io/sdk/
  */
-abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
+abstract class AbstractRequest extends \League\Omnipay\Common\Message\AbstractRequest
 {
     const API_VERSION = '119.0';
 

--- a/src/Message/AbstractRestRequest.php
+++ b/src/Message/AbstractRestRequest.php
@@ -6,6 +6,7 @@
 namespace Omnipay\PayPal\Message;
 
 use League\Omnipay\Common\Exception\InvalidResponseException;
+use League\Omnipay\Common\Http\Factory;
 
 /**
  * PayPal Abstract REST Request
@@ -122,20 +123,10 @@ abstract class AbstractRestRequest extends \League\Omnipay\Common\Message\Abstra
 
     public function sendData($data)
     {
-        // don't throw exceptions for 4xx errors
-        $this->httpClient->getEventDispatcher()->addListener(
-            'request.error',
-            function ($event) {
-                if ($event['response']->isClientError()) {
-                    $event->stopPropagation();
-                }
-            }
-        );
-
         // Guzzle HTTP Client createRequest does funny things when a GET request
         // has attached data, so don't send the data if the method is GET.
         if ($this->getHttpMethod() == 'GET') {
-            $httpRequest = $this->httpClient->createRequest(
+            $httpRequest = Factory::createRequest(
                 $this->getHttpMethod(),
                 $this->getEndpoint() . '?' . http_build_query($data),
                 array(
@@ -145,7 +136,7 @@ abstract class AbstractRestRequest extends \League\Omnipay\Common\Message\Abstra
                 )
             );
         } else {
-            $httpRequest = $this->httpClient->createRequest(
+            $httpRequest = Factory::createRequest(
                 $this->getHttpMethod(),
                 $this->getEndpoint(),
                 array(
@@ -163,11 +154,10 @@ abstract class AbstractRestRequest extends \League\Omnipay\Common\Message\Abstra
         // echo "Data == " . json_encode($data) . "\n";
 
         try {
-            $httpRequest->getCurlOptions()->set(CURLOPT_SSLVERSION, 6); // CURL_SSLVERSION_TLSv1_2 for libcurl < 7.35
-            $httpResponse = $httpRequest->send();
+            $httpResponse = $this->httpClient->sendRequest($httpRequest);
             // Empty response body should be parsed also as and empty array
-            $body = $httpResponse->getBody(true);
-            $jsonToArrayResponse = !empty($body) ? $httpResponse->json() : array();
+            $body = $httpResponse->getBody()->getContents();
+            $jsonToArrayResponse = !empty($body) ? json_decode($body, true) : array();
             return $this->response = $this->createResponse($jsonToArrayResponse, $httpResponse->getStatusCode());
         } catch (\Exception $e) {
             throw new InvalidResponseException(

--- a/src/Message/AbstractRestRequest.php
+++ b/src/Message/AbstractRestRequest.php
@@ -5,7 +5,7 @@
 
 namespace Omnipay\PayPal\Message;
 
-use Omnipay\Common\Exception\InvalidResponseException;
+use League\Omnipay\Common\Exception\InvalidResponseException;
 
 /**
  * PayPal Abstract REST Request
@@ -28,7 +28,7 @@ use Omnipay\Common\Exception\InvalidResponseException;
  * @link http://paypal.github.io/sdk/
  * @see Omnipay\PayPal\RestGateway
  */
-abstract class AbstractRestRequest extends \Omnipay\Common\Message\AbstractRequest
+abstract class AbstractRestRequest extends \League\Omnipay\Common\Message\AbstractRequest
 {
     const API_VERSION = 'v1';
 

--- a/src/Message/CaptureRequest.php
+++ b/src/Message/CaptureRequest.php
@@ -13,7 +13,7 @@ class CaptureRequest extends AbstractRequest
 
         $data = $this->getBaseData();
         $data['METHOD'] = 'DoCapture';
-        $data['AMT'] = $this->getAmount();
+        $data['AMT'] = $this->getAmount()->getFormatted();
         $data['CURRENCYCODE'] = $this->getCurrency();
         $data['AUTHORIZATIONID'] = $this->getTransactionReference();
         $data['COMPLETETYPE'] = 'Complete';

--- a/src/Message/ExpressAuthorizeRequest.php
+++ b/src/Message/ExpressAuthorizeRequest.php
@@ -139,18 +139,19 @@ class ExpressAuthorizeRequest extends AbstractRequest
         $data['PAYMENTREQUEST_0_INSURANCEAMT'] = $this->getInsuranceAmount();
         $data['PAYMENTREQUEST_0_SELLERPAYPALACCOUNTID'] = $this->getSellerPaypalAccountId();
 
-        $card = $this->getCard();
-        if ($card) {
-            $data['PAYMENTREQUEST_0_SHIPTONAME'] = $card->getName();
-            $data['PAYMENTREQUEST_0_SHIPTOSTREET'] = $card->getAddress1();
-            $data['PAYMENTREQUEST_0_SHIPTOSTREET2'] = $card->getAddress2();
-            $data['PAYMENTREQUEST_0_SHIPTOCITY'] = $card->getCity();
-            $data['PAYMENTREQUEST_0_SHIPTOSTATE'] = $card->getState();
-            $data['PAYMENTREQUEST_0_SHIPTOCOUNTRYCODE'] = $card->getCountry();
-            $data['PAYMENTREQUEST_0_SHIPTOZIP'] = $card->getPostcode();
-            $data['PAYMENTREQUEST_0_SHIPTOPHONENUM'] = $card->getPhone();
-            $data['EMAIL'] = $card->getEmail();
+        $customer = $this->getCustomer();
+        if ($customer) {
+            $data['PAYMENTREQUEST_0_SHIPTONAME'] = $customer->getName();
+            $data['PAYMENTREQUEST_0_SHIPTOSTREET'] = $customer->getAddress1();
+            $data['PAYMENTREQUEST_0_SHIPTOSTREET2'] = $customer->getAddress2();
+            $data['PAYMENTREQUEST_0_SHIPTOCITY'] = $customer->getCity();
+            $data['PAYMENTREQUEST_0_SHIPTOSTATE'] = $customer->getState();
+            $data['PAYMENTREQUEST_0_SHIPTOCOUNTRYCODE'] = $customer->getCountry();
+            $data['PAYMENTREQUEST_0_SHIPTOZIP'] = $customer->getPostcode();
+            $data['PAYMENTREQUEST_0_SHIPTOPHONENUM'] = $customer->getPhone();
+            $data['EMAIL'] = $customer->getEmail();
         }
+
 
         $data = array_merge($data, $this->getItemData());
 

--- a/src/Message/ExpressAuthorizeRequest.php
+++ b/src/Message/ExpressAuthorizeRequest.php
@@ -2,7 +2,7 @@
 
 namespace Omnipay\PayPal\Message;
 
-use Omnipay\Common\Exception\InvalidRequestException;
+use League\Omnipay\Common\Exception\InvalidRequestException;
 use Omnipay\PayPal\Support\InstantUpdateApi\ShippingOption;
 
 /**

--- a/src/Message/ExpressAuthorizeRequest.php
+++ b/src/Message/ExpressAuthorizeRequest.php
@@ -86,7 +86,7 @@ class ExpressAuthorizeRequest extends AbstractRequest
         $data = $this->getBaseData();
         $data['METHOD'] = 'SetExpressCheckout';
         $data['PAYMENTREQUEST_0_PAYMENTACTION'] = 'Authorization';
-        $data['PAYMENTREQUEST_0_AMT'] = $this->getAmount();
+        $data['PAYMENTREQUEST_0_AMT'] = $this->getAmount()->getFormatted();
         $data['PAYMENTREQUEST_0_CURRENCYCODE'] = $this->getCurrency();
         $data['PAYMENTREQUEST_0_INVNUM'] = $this->getTransactionId();
         $data['PAYMENTREQUEST_0_DESC'] = $this->getDescription();

--- a/src/Message/ExpressAuthorizeResponse.php
+++ b/src/Message/ExpressAuthorizeResponse.php
@@ -2,7 +2,7 @@
 
 namespace Omnipay\PayPal\Message;
 
-use Omnipay\Common\Message\RedirectResponseInterface;
+use League\Omnipay\Common\Message\RedirectResponseInterface;
 
 /**
  * PayPal Express Authorize Response

--- a/src/Message/ExpressCompleteAuthorizeRequest.php
+++ b/src/Message/ExpressCompleteAuthorizeRequest.php
@@ -14,7 +14,7 @@ class ExpressCompleteAuthorizeRequest extends AbstractRequest
         $data = $this->getBaseData();
         $data['METHOD'] = 'DoExpressCheckoutPayment';
         $data['PAYMENTREQUEST_0_PAYMENTACTION'] = 'Authorization';
-        $data['PAYMENTREQUEST_0_AMT'] = $this->getAmount();
+        $data['PAYMENTREQUEST_0_AMT'] = $this->getAmount()->getFormatted();
         $data['PAYMENTREQUEST_0_CURRENCYCODE'] = $this->getCurrency();
         $data['PAYMENTREQUEST_0_INVNUM'] = $this->getTransactionId();
         $data['PAYMENTREQUEST_0_DESC'] = $this->getDescription();

--- a/src/Message/ExpressCompleteAuthorizeRequest.php
+++ b/src/Message/ExpressCompleteAuthorizeRequest.php
@@ -27,8 +27,8 @@ class ExpressCompleteAuthorizeRequest extends AbstractRequest
         $data['PAYMENTREQUEST_0_SHIPDISCAMT'] = $this->getShippingDiscount();
         $data['PAYMENTREQUEST_0_INSURANCEAMT'] = $this->getInsuranceAmount();
 
-        $data['TOKEN'] = $this->getToken() ? $this->getToken() : $this->httpRequest->query->get('token');
-        $data['PAYERID'] = $this->getPayerID() ? $this->getPayerID() : $this->httpRequest->query->get('PayerID');
+        $data['TOKEN'] = $this->getToken() ? $this->getToken() : $this->query('token');
+        $data['PAYERID'] = $this->getPayerID() ? $this->getPayerID() : $this->query('PayerID');
 
         $data = array_merge($data, $this->getItemData());
 

--- a/src/Message/ExpressFetchCheckoutRequest.php
+++ b/src/Message/ExpressFetchCheckoutRequest.php
@@ -18,7 +18,7 @@ class ExpressFetchCheckoutRequest extends AbstractRequest
         if ($this->getToken()) {
             $data['TOKEN'] = $this->getToken();
         } else {
-            $data['TOKEN'] = $this->httpRequest->query->get('token');
+            $data['TOKEN'] = $this->query('token');
         }
 
         return $data;

--- a/src/Message/ExpressTransactionSearchRequest.php
+++ b/src/Message/ExpressTransactionSearchRequest.php
@@ -83,7 +83,7 @@ class ExpressTransactionSearchRequest extends AbstractRequest
         if ($this->getAmount()) {
             $this->validate('currency');
 
-            $data['AMT'] = $this->getAmount();
+            $data['AMT'] = $this->getAmount()->getFormatted();
             $data['CURRENCYCODE'] = $this->getCurrency();
         }
 

--- a/src/Message/ExpressTransactionSearchRequest.php
+++ b/src/Message/ExpressTransactionSearchRequest.php
@@ -108,7 +108,7 @@ class ExpressTransactionSearchRequest extends AbstractRequest
 
     /**
      * @param DateTime|string $date
-     * @return \Omnipay\Common\Message\AbstractRequest
+     * @return \League\Omnipay\Common\Message\AbstractRequest
      */
     public function setStartDate($date)
     {
@@ -129,7 +129,7 @@ class ExpressTransactionSearchRequest extends AbstractRequest
 
     /**
      * @param DateTime|string $date
-     * @return \Omnipay\Common\Message\AbstractRequest
+     * @return \League\Omnipay\Common\Message\AbstractRequest
      */
     public function setEndDate($date)
     {
@@ -150,7 +150,7 @@ class ExpressTransactionSearchRequest extends AbstractRequest
 
     /**
      * @param string $salutation
-     * @return \Omnipay\Common\Message\AbstractRequest
+     * @return \League\Omnipay\Common\Message\AbstractRequest
      */
     public function setSalutation($salutation)
     {
@@ -167,7 +167,7 @@ class ExpressTransactionSearchRequest extends AbstractRequest
 
     /**
      * @param string $firstName
-     * @return \Omnipay\Common\Message\AbstractRequest
+     * @return \League\Omnipay\Common\Message\AbstractRequest
      */
     public function setFirstName($firstName)
     {
@@ -184,7 +184,7 @@ class ExpressTransactionSearchRequest extends AbstractRequest
 
     /**
      * @param string $middleName
-     * @return \Omnipay\Common\Message\AbstractRequest
+     * @return \League\Omnipay\Common\Message\AbstractRequest
      */
     public function setMiddleName($middleName)
     {
@@ -201,7 +201,7 @@ class ExpressTransactionSearchRequest extends AbstractRequest
 
     /**
      * @param string $lastName
-     * @return \Omnipay\Common\Message\AbstractRequest
+     * @return \League\Omnipay\Common\Message\AbstractRequest
      */
     public function setLastName($lastName)
     {
@@ -218,7 +218,7 @@ class ExpressTransactionSearchRequest extends AbstractRequest
 
     /**
      * @param string $suffix
-     * @return \Omnipay\Common\Message\AbstractRequest
+     * @return \League\Omnipay\Common\Message\AbstractRequest
      */
     public function setSuffix($suffix)
     {
@@ -235,7 +235,7 @@ class ExpressTransactionSearchRequest extends AbstractRequest
 
     /**
      * @param string $email
-     * @return \Omnipay\Common\Message\AbstractRequest
+     * @return \League\Omnipay\Common\Message\AbstractRequest
      */
     public function setEmail($email)
     {
@@ -252,7 +252,7 @@ class ExpressTransactionSearchRequest extends AbstractRequest
 
     /**
      * @param string $receiver
-     * @return \Omnipay\Common\Message\AbstractRequest
+     * @return \League\Omnipay\Common\Message\AbstractRequest
      */
     public function setReceiver($receiver)
     {
@@ -269,7 +269,7 @@ class ExpressTransactionSearchRequest extends AbstractRequest
 
     /**
      * @param string $receiptId
-     * @return \Omnipay\Common\Message\AbstractRequest
+     * @return \League\Omnipay\Common\Message\AbstractRequest
      */
     public function setReceiptId($receiptId)
     {
@@ -286,7 +286,7 @@ class ExpressTransactionSearchRequest extends AbstractRequest
 
     /**
      * @param string $invoiceNumber
-     * @return \Omnipay\Common\Message\AbstractRequest
+     * @return \League\Omnipay\Common\Message\AbstractRequest
      */
     public function setInvoiceNumber($invoiceNumber)
     {
@@ -303,7 +303,7 @@ class ExpressTransactionSearchRequest extends AbstractRequest
 
     /**
      * @param string $auctionItemNumber
-     * @return \Omnipay\Common\Message\AbstractRequest
+     * @return \League\Omnipay\Common\Message\AbstractRequest
      */
     public function setAuctionItemNumber($auctionItemNumber)
     {
@@ -320,7 +320,7 @@ class ExpressTransactionSearchRequest extends AbstractRequest
 
     /**
      * @param string $transactionClass
-     * @return \Omnipay\Common\Message\AbstractRequest
+     * @return \League\Omnipay\Common\Message\AbstractRequest
      */
     public function setTransactionClass($transactionClass)
     {
@@ -337,7 +337,7 @@ class ExpressTransactionSearchRequest extends AbstractRequest
 
     /**
      * @param string $status
-     * @return \Omnipay\Common\Message\AbstractRequest
+     * @return \League\Omnipay\Common\Message\AbstractRequest
      */
     public function setStatus($status)
     {
@@ -354,7 +354,7 @@ class ExpressTransactionSearchRequest extends AbstractRequest
 
     /**
      * @param string $profileId
-     * @return \Omnipay\Common\Message\AbstractRequest
+     * @return \League\Omnipay\Common\Message\AbstractRequest
      */
     public function setProfileId($profileId)
     {

--- a/src/Message/ExpressTransactionSearchResponse.php
+++ b/src/Message/ExpressTransactionSearchResponse.php
@@ -2,7 +2,7 @@
 
 namespace Omnipay\PayPal\Message;
 
-use Omnipay\Common\Message\RequestInterface;
+use League\Omnipay\Common\Message\RequestInterface;
 
 /**
  * Response for Transaction Search request

--- a/src/Message/ProAuthorizeRequest.php
+++ b/src/Message/ProAuthorizeRequest.php
@@ -28,15 +28,15 @@ class ProAuthorizeRequest extends AbstractRequest
         $data['CVV2'] = $this->getCard()->getCvv();
         $data['ISSUENUMBER'] = $this->getCard()->getIssueNumber();
         $data['IPADDRESS'] = $this->getClientIp();
-        $data['FIRSTNAME'] = $this->getCard()->getFirstName();
-        $data['LASTNAME'] = $this->getCard()->getLastName();
-        $data['EMAIL'] = $this->getCard()->getEmail();
-        $data['STREET'] = $this->getCard()->getAddress1();
-        $data['STREET2'] = $this->getCard()->getAddress2();
-        $data['CITY'] = $this->getCard()->getCity();
-        $data['STATE'] = $this->getCard()->getState();
-        $data['ZIP'] = $this->getCard()->getPostcode();
-        $data['COUNTRYCODE'] = strtoupper($this->getCard()->getCountry());
+        $data['FIRSTNAME'] = $this->getCustomer()->getFirstName();
+        $data['LASTNAME'] = $this->getCustomer()->getLastName();
+        $data['EMAIL'] = $this->getCustomer()->getEmail();
+        $data['STREET'] = $this->getCustomer()->getAddress1();
+        $data['STREET2'] = $this->getCustomer()->getAddress2();
+        $data['CITY'] = $this->getCustomer()->getCity();
+        $data['STATE'] = $this->getCustomer()->getState();
+        $data['ZIP'] = $this->getCustomer()->getPostcode();
+        $data['COUNTRYCODE'] = strtoupper($this->getCustomer()->getCountry());
 
         return $data;
     }

--- a/src/Message/ProAuthorizeRequest.php
+++ b/src/Message/ProAuthorizeRequest.php
@@ -15,7 +15,7 @@ class ProAuthorizeRequest extends AbstractRequest
         $data = $this->getBaseData();
         $data['METHOD'] = 'DoDirectPayment';
         $data['PAYMENTACTION'] = 'Authorization';
-        $data['AMT'] = $this->getAmount();
+        $data['AMT'] = $this->getAmount()->getFormatted();
         $data['CURRENCYCODE'] = $this->getCurrency();
         $data['INVNUM'] = $this->getTransactionId();
         $data['DESC'] = $this->getDescription();

--- a/src/Message/RefundRequest.php
+++ b/src/Message/RefundRequest.php
@@ -15,9 +15,9 @@ class RefundRequest extends AbstractRequest
         $data['METHOD'] = 'RefundTransaction';
         $data['TRANSACTIONID'] = $this->getTransactionReference();
         $data['REFUNDTYPE'] = 'Full';
-        if ($this->getAmount() > 0) {
+        if ($this->getAmount() && $this->getAmount()->getInteger() > 0) {
             $data['REFUNDTYPE'] = 'Partial';
-            $data['AMT'] = $this->getAmount();
+            $data['AMT'] = $this->getAmount()->getFormatted();
             $data['CURRENCYCODE'] = $this->getCurrency();
         }
 

--- a/src/Message/Response.php
+++ b/src/Message/Response.php
@@ -2,8 +2,8 @@
 
 namespace Omnipay\PayPal\Message;
 
-use Omnipay\Common\Message\AbstractResponse;
-use Omnipay\Common\Message\RequestInterface;
+use League\Omnipay\Common\Message\AbstractResponse;
+use League\Omnipay\Common\Message\RequestInterface;
 
 /**
  * PayPal Response

--- a/src/Message/Response.php
+++ b/src/Message/Response.php
@@ -16,6 +16,11 @@ class Response extends AbstractResponse
         parse_str($data, $this->data);
     }
 
+    public function isCompleted()
+    {
+        return false;
+    }
+
     public function isPending()
     {
         return isset($this->data['PAYMENTINFO_0_PAYMENTSTATUS'])

--- a/src/Message/RestAuthorizeRequest.php
+++ b/src/Message/RestAuthorizeRequest.php
@@ -229,7 +229,7 @@ class RestAuthorizeRequest extends AbstractRestRequest
                 array(
                     'description' => $this->getDescription(),
                     'amount' => array(
-                        'total' => $this->getAmount(),
+                        'total' => $this->getAmount()->getFormatted(),
                         'currency' => $this->getCurrency(),
                     ),
                 )
@@ -245,7 +245,7 @@ class RestAuthorizeRequest extends AbstractRestRequest
                     'name' => $item->getName(),
                     'description' => $item->getDescription(),
                     'quantity' => $item->getQuantity(),
-                    'price' => (new Amount($item->getPrice(), $this->getCurrency()))->getFormatted(),
+                    'price' => Amount::fromDecimal($item->getPrice(), $this->getCurrency())->getFormatted(),
                     'currency' => $this->getCurrency()
                 );
             }

--- a/src/Message/RestAuthorizeRequest.php
+++ b/src/Message/RestAuthorizeRequest.php
@@ -5,6 +5,8 @@
 
 namespace Omnipay\PayPal\Message;
 
+use League\Omnipay\Common\Amount;
+
 /**
  * PayPal REST Authorize Request
  *
@@ -243,7 +245,7 @@ class RestAuthorizeRequest extends AbstractRestRequest
                     'name' => $item->getName(),
                     'description' => $item->getDescription(),
                     'quantity' => $item->getQuantity(),
-                    'price' => $this->formatCurrency($item->getPrice()),
+                    'price' => (new Amount($item->getPrice(), $this->getCurrency()))->getFormatted(),
                     'currency' => $this->getCurrency()
                 );
             }
@@ -269,22 +271,22 @@ class RestAuthorizeRequest extends AbstractRestRequest
                     'expire_month' => $this->getCard()->getExpiryMonth(),
                     'expire_year' => $this->getCard()->getExpiryYear(),
                     'cvv2' => $this->getCard()->getCvv(),
-                    'first_name' => $this->getCard()->getFirstName(),
-                    'last_name' => $this->getCard()->getLastName(),
+                    'first_name' => $this->getCustomer()->getFirstName(),
+                    'last_name' => $this->getCustomer()->getLastName(),
                     'billing_address' => array(
-                        'line1' => $this->getCard()->getAddress1(),
-                        //'line2' => $this->getCard()->getAddress2(),
-                        'city' => $this->getCard()->getCity(),
-                        'state' => $this->getCard()->getState(),
-                        'postal_code' => $this->getCard()->getPostcode(),
-                        'country_code' => strtoupper($this->getCard()->getCountry()),
+                        'line1' => $this->getCustomer()->getAddress1(),
+                        //'line2' => $this->getCustomer()->getAddress2(),
+                        'city' => $this->getCustomer()->getCity(),
+                        'state' => $this->getCustomer()->getState(),
+                        'postal_code' => $this->getCustomer()->getPostcode(),
+                        'country_code' => strtoupper($this->getCustomer()->getCountry()),
                     )
                 )
             );
 
             // There's currently a quirk with the REST API that requires line2 to be
             // non-empty if it's present. Jul 14, 2014
-            $line2 = $this->getCard()->getAddress2();
+            $line2 = $this->getCustomer()->getAddress2();
             if (!empty($line2)) {
                 $data['payer']['funding_instruments'][0]['credit_card']['billing_address']['line2'] = $line2;
             }

--- a/src/Message/RestAuthorizeResponse.php
+++ b/src/Message/RestAuthorizeResponse.php
@@ -5,7 +5,7 @@
 
 namespace Omnipay\PayPal\Message;
 
-use Omnipay\Common\Message\RedirectResponseInterface;
+use League\Omnipay\Common\Message\RedirectResponseInterface;
 
 /**
  * PayPal REST Authorize Response

--- a/src/Message/RestCaptureRequest.php
+++ b/src/Message/RestCaptureRequest.php
@@ -46,7 +46,7 @@ class RestCaptureRequest extends AbstractRestRequest
         return array(
             'amount' => array(
                 'currency' => $this->getCurrency(),
-                'total' => $this->getAmount(),
+                'total' => $this->getAmount()->getFormatted(),
             ),
             'is_final_capture' => true,
         );

--- a/src/Message/RestCreateCardRequest.php
+++ b/src/Message/RestCreateCardRequest.php
@@ -81,21 +81,21 @@ class RestCreateCardRequest extends AbstractRestRequest
             'expire_month' => $this->getCard()->getExpiryMonth(),
             'expire_year' => $this->getCard()->getExpiryYear(),
             'cvv2' => $this->getCard()->getCvv(),
-            'first_name' => $this->getCard()->getFirstName(),
-            'last_name' => $this->getCard()->getLastName(),
+            'first_name' => $this->getCustomer()->getFirstName(),
+            'last_name' => $this->getCustomer()->getLastName(),
             'billing_address' => array(
-                'line1' => $this->getCard()->getAddress1(),
-                //'line2' => $this->getCard()->getAddress2(),
-                'city' => $this->getCard()->getCity(),
-                'state' => $this->getCard()->getState(),
-                'postal_code' => $this->getCard()->getPostcode(),
-                'country_code' => strtoupper($this->getCard()->getCountry()),
+                'line1' => $this->getCustomer()->getAddress1(),
+                //'line2' => $this->$this->getCustomer()->getAddress2(),
+                'city' => $this->getCustomer()->getCity(),
+                'state' => $this->getCustomer()->getState(),
+                'postal_code' => $this->getCustomer()->getPostcode(),
+                'country_code' => strtoupper($this->getCustomer()->getCountry()),
             )
         );
 
         // There's currently a quirk with the REST API that requires line2 to be
         // non-empty if it's present. Jul 14, 2014
-        $line2 = $this->getCard()->getAddress2();
+        $line2 = $this->getCustomer()->getAddress2();
         if (!empty($line2)) {
             $data['billing_address']['line2'] = $line2;
         }

--- a/src/Message/RestRefundCaptureRequest.php
+++ b/src/Message/RestRefundCaptureRequest.php
@@ -23,7 +23,7 @@ class RestRefundCaptureRequest extends AbstractRestRequest
         return array(
             'amount' => array(
                 'currency' => $this->getCurrency(),
-                'total' => $this->getAmount(),
+                'total' => $this->getAmount()->getFormatted(),
             ),
             'description' => $this->getDescription(),
         );

--- a/src/Message/RestRefundRequest.php
+++ b/src/Message/RestRefundRequest.php
@@ -53,11 +53,11 @@ class RestRefundRequest extends AbstractRestRequest
     {
         $this->validate('transactionReference');
 
-        if ($this->getAmount() > 0) {
+        if ($this->getAmount() && $this->getAmount()->getInteger() > 0) {
             return array(
                 'amount' => array(
                     'currency' => $this->getCurrency(),
-                    'total' => $this->getAmount(),
+                    'total' => $this->getAmount()->getFormatted(),
                 ),
                 'description' => $this->getDescription(),
             );

--- a/src/Message/RestResponse.php
+++ b/src/Message/RestResponse.php
@@ -20,6 +20,11 @@ class RestResponse extends AbstractResponse
         parent::__construct($request, $data);
         $this->statusCode = $statusCode;
     }
+    
+    public function isCompleted()
+    {
+        return false;
+    }
 
     public function isSuccessful()
     {

--- a/src/Message/RestResponse.php
+++ b/src/Message/RestResponse.php
@@ -5,8 +5,8 @@
 
 namespace Omnipay\PayPal\Message;
 
-use Omnipay\Common\Message\AbstractResponse;
-use Omnipay\Common\Message\RequestInterface;
+use League\Omnipay\Common\Message\AbstractResponse;
+use League\Omnipay\Common\Message\RequestInterface;
 
 /**
  * PayPal REST Response

--- a/src/Message/RestTokenRequest.php
+++ b/src/Message/RestTokenRequest.php
@@ -37,9 +37,9 @@ class RestTokenRequest extends AbstractRestRequest
             $this->getEndpoint(),
             array(
                 'Accept' => 'application/json',
-                'Authorization' => 'Basic '. base64_encode($this->getClientId().':'.$this->getSecret())
+                'Authorization' => 'Basic asd'. base64_encode($this->getClientId().':'.$this->getSecret())
             ),
-            $data
+            json_encode($data)
         );
 
         $httpResponse = $this->httpClient->sendRequest($httpRequest);

--- a/src/Message/RestTokenRequest.php
+++ b/src/Message/RestTokenRequest.php
@@ -37,7 +37,7 @@ class RestTokenRequest extends AbstractRestRequest
             $this->getEndpoint(),
             array(
                 'Accept' => 'application/json',
-                'Authorization' => 'Basic asd'. base64_encode($this->getClientId().':'.$this->getSecret())
+                'Authorization' => 'Basic '. base64_encode($this->getClientId().':'.$this->getSecret())
             ),
             json_encode($data)
         );

--- a/src/Message/RestTokenRequest.php
+++ b/src/Message/RestTokenRequest.php
@@ -5,6 +5,8 @@
 
 namespace Omnipay\PayPal\Message;
 
+use League\Omnipay\Common\Http\Factory;
+
 /**
  * PayPal REST Token Request
  *
@@ -30,27 +32,21 @@ class RestTokenRequest extends AbstractRestRequest
 
     public function sendData($data)
     {
-        // don't throw exceptions for 4xx errors
-        $this->httpClient->getEventDispatcher()->addListener(
-            'request.error',
-            function ($event) {
-                if ($event['response']->isClientError()) {
-                    $event->stopPropagation();
-                }
-            }
-        );
-
-        $httpRequest = $this->httpClient->createRequest(
+        $httpRequest = Factory::createRequest(
             $this->getHttpMethod(),
             $this->getEndpoint(),
-            array('Accept' => 'application/json'),
+            array(
+                'Accept' => 'application/json',
+                'Authorization' => 'Basic '. base64_encode($this->getClientId().':'.$this->getSecret())
+            ),
             $data
         );
 
-        $httpResponse = $httpRequest->setAuth($this->getClientId(), $this->getSecret())->send();
+        $httpResponse = $this->httpClient->sendRequest($httpRequest);
+
         // Empty response body should be parsed also as and empty array
-        $body = $httpResponse->getBody(true);
-        $jsonToArrayResponse = !empty($body) ? $httpResponse->json() : array();
+        $body = $httpResponse->getBody()->getContents();
+        $jsonToArrayResponse = !empty($body) ? json_decode($body, true) : array();
         return $this->response = new RestResponse($this, $jsonToArrayResponse, $httpResponse->getStatusCode());
     }
 }

--- a/src/PayPalItem.php
+++ b/src/PayPalItem.php
@@ -5,7 +5,7 @@
 
 namespace Omnipay\PayPal;
 
-use Omnipay\Common\Item;
+use League\Omnipay\Common\Item;
 
 /**
  * Class PayPalItem

--- a/src/PayPalItemBag.php
+++ b/src/PayPalItemBag.php
@@ -5,8 +5,8 @@
 
 namespace Omnipay\PayPal;
 
-use Omnipay\Common\ItemBag;
-use Omnipay\Common\ItemInterface;
+use League\Omnipay\Common\ItemBag;
+use League\Omnipay\Common\ItemInterface;
 
 /**
  * Class PayPalItemBag

--- a/src/ProGateway.php
+++ b/src/ProGateway.php
@@ -2,7 +2,7 @@
 
 namespace Omnipay\PayPal;
 
-use Omnipay\Common\AbstractGateway;
+use League\Omnipay\Common\AbstractGateway;
 
 /**
  * PayPal Pro Class

--- a/src/RestGateway.php
+++ b/src/RestGateway.php
@@ -5,7 +5,7 @@
 
 namespace Omnipay\PayPal;
 
-use Omnipay\Common\AbstractGateway;
+use League\Omnipay\Common\AbstractGateway;
 use Omnipay\PayPal\Message\ProAuthorizeRequest;
 use Omnipay\PayPal\Message\CaptureRequest;
 use Omnipay\PayPal\Message\RefundRequest;

--- a/tests/ExpressGatewayTest.php
+++ b/tests/ExpressGatewayTest.php
@@ -29,6 +29,7 @@ class ExpressGatewayTest extends GatewayTestCase
 
         $this->options = array(
             'amount' => '10.00',
+            'currency' => 'USD',
             'returnUrl' => 'https://www.example.com/return',
             'cancelUrl' => 'https://www.example.com/cancel',
         );

--- a/tests/ExpressGatewayTest.php
+++ b/tests/ExpressGatewayTest.php
@@ -2,7 +2,7 @@
 
 namespace Omnipay\PayPal;
 
-use Omnipay\Tests\GatewayTestCase;
+use League\Omnipay\Tests\GatewayTestCase;
 
 class ExpressGatewayTest extends GatewayTestCase
 {

--- a/tests/ExpressGatewayTest.php
+++ b/tests/ExpressGatewayTest.php
@@ -164,11 +164,14 @@ class ExpressGatewayTest extends GatewayTestCase
     {
         $this->setMockHttpResponse('ExpressPurchaseSuccess.txt');
 
+        $httpRequest = $this->getHttpRequest();
+        $query = $httpRequest->getQueryParams();
+        $query['token'] = 'GET_TOKEN';
+        $query['PayerID'] = 'GET_PAYERID';
 
-        $this->getHttpRequest()->query->replace(array(
-            'token' => 'GET_TOKEN',
-            'PayerID' => 'GET_PAYERID',
-        ));
+        $httpRequest = $httpRequest->withQueryParams($query);
+
+        $this->gateway = new ExpressGateway($this->getHttpClient(), $httpRequest);
 
         $response = $this->gateway->completePurchase(array(
             'amount' => '10.00',
@@ -177,7 +180,9 @@ class ExpressGatewayTest extends GatewayTestCase
 
         $httpRequests = $this->getMockedRequests();
         $httpRequest = $httpRequests[0];
-        parse_str((string)$httpRequest->getBody()->getContent(), $postData);
+
+        parse_str((string)$httpRequest->getBody()->getContents(), $postData);
+
         $this->assertSame('GET_TOKEN', $postData['TOKEN']);
         $this->assertSame('GET_PAYERID', $postData['PAYERID']);
     }
@@ -186,11 +191,14 @@ class ExpressGatewayTest extends GatewayTestCase
     {
         $this->setMockHttpResponse('ExpressPurchaseSuccess.txt');
 
-        // Those values should not be used if custom token or payerid are passed
-        $this->getHttpRequest()->query->replace(array(
-            'token' => 'GET_TOKEN',
-            'PayerID' => 'GET_PAYERID',
-        ));
+        $httpRequest = $this->getHttpRequest();
+        $query = $httpRequest->getQueryParams();
+        $query['token'] = 'GET_TOKEN';
+        $query['PayerID'] = 'GET_PAYERID';
+
+        $httpRequest = $httpRequest->withQueryParams($query);
+
+        $this->gateway = new ExpressGateway($this->getHttpClient(), $httpRequest);
 
         $response = $this->gateway->completePurchase(array(
             'amount' => '10.00',

--- a/tests/ExpressGatewayTest.php
+++ b/tests/ExpressGatewayTest.php
@@ -164,6 +164,7 @@ class ExpressGatewayTest extends GatewayTestCase
     {
         $this->setMockHttpResponse('ExpressPurchaseSuccess.txt');
 
+
         $this->getHttpRequest()->query->replace(array(
             'token' => 'GET_TOKEN',
             'PayerID' => 'GET_PAYERID',
@@ -176,7 +177,7 @@ class ExpressGatewayTest extends GatewayTestCase
 
         $httpRequests = $this->getMockedRequests();
         $httpRequest = $httpRequests[0];
-        parse_str((string)$httpRequest->getBody(), $postData);
+        parse_str((string)$httpRequest->getBody()->getContent(), $postData);
         $this->assertSame('GET_TOKEN', $postData['TOKEN']);
         $this->assertSame('GET_PAYERID', $postData['PAYERID']);
     }

--- a/tests/ExpressInContextGatewayTest.php
+++ b/tests/ExpressInContextGatewayTest.php
@@ -2,7 +2,7 @@
 
 namespace Omnipay\PayPal;
 
-use Omnipay\Tests\GatewayTestCase;
+use League\Omnipay\Tests\GatewayTestCase;
 
 class ExpressInContextGatewayTest extends GatewayTestCase
 {

--- a/tests/ExpressInContextGatewayTest.php
+++ b/tests/ExpressInContextGatewayTest.php
@@ -29,6 +29,7 @@ class ExpressInContextGatewayTest extends GatewayTestCase
 
         $this->options = array(
             'amount' => '10.00',
+            'currency' => 'USD',
             'returnUrl' => 'https://www.example.com/return',
             'cancelUrl' => 'https://www.example.com/cancel',
         );

--- a/tests/Message/CaptureRequestTest.php
+++ b/tests/Message/CaptureRequestTest.php
@@ -3,7 +3,7 @@
 namespace Omnipay\PayPal\Message;
 
 use Omnipay\PayPal\Message\CaptureRequest;
-use Omnipay\Tests\TestCase;
+use League\Omnipay\Tests\TestCase;
 
 class CaptureRequestTest extends TestCase
 {

--- a/tests/Message/ExpressAuthorizeRequestTest.php
+++ b/tests/Message/ExpressAuthorizeRequestTest.php
@@ -23,6 +23,7 @@ class ExpressAuthorizeRequestTest extends TestCase
         $this->request->initialize(
             array(
                 'amount' => '10.00',
+                'currency' => 'USD',
                 'returnUrl' => 'https://www.example.com/return',
                 'cancelUrl' => 'https://www.example.com/cancel',
             )

--- a/tests/Message/ExpressAuthorizeRequestTest.php
+++ b/tests/Message/ExpressAuthorizeRequestTest.php
@@ -3,6 +3,7 @@
 namespace Omnipay\PayPal\Message;
 
 use League\Omnipay\Common\CreditCard;
+use League\Omnipay\Common\Customer;
 use Omnipay\PayPal\Message\ExpressAuthorizeRequest;
 use Omnipay\PayPal\Support\InstantUpdateApi\ShippingOption;
 use League\Omnipay\Tests\TestCase;
@@ -28,7 +29,7 @@ class ExpressAuthorizeRequestTest extends TestCase
         );
     }
 
-    public function testGetDataWithoutCard()
+    public function testGetDataWithoutCustomer()
     {
         $this->request->initialize(array(
             'amount' => '10.00',
@@ -65,7 +66,7 @@ class ExpressAuthorizeRequestTest extends TestCase
         $this->assertSame('1-801-FLOWERS', $data['CUSTOMERSERVICENUMBER']);
     }
 
-    public function testGetDataWithCard()
+    public function testGetDataWithCustomer()
     {
         $this->request->initialize(array(
             'amount' => '10.00',
@@ -88,7 +89,7 @@ class ExpressAuthorizeRequestTest extends TestCase
             'sellerPaypalAccountId' => 'billing@example.com',
         ));
 
-        $card = new CreditCard(array(
+        $customer = new Customer(array(
             'name' => 'John Doe',
             'address1' => '123 NW Blvd',
             'address2' => 'Lynx Lane',
@@ -99,7 +100,7 @@ class ExpressAuthorizeRequestTest extends TestCase
             'phone' => '555-555-5555',
             'email' => 'test@email.com',
         ));
-        $this->request->setCard($card);
+        $this->request->setCustomer($customer);
 
         $expected = array(
             'METHOD' => 'SetExpressCheckout',

--- a/tests/Message/ExpressAuthorizeRequestTest.php
+++ b/tests/Message/ExpressAuthorizeRequestTest.php
@@ -2,10 +2,10 @@
 
 namespace Omnipay\PayPal\Message;
 
-use Omnipay\Common\CreditCard;
+use League\Omnipay\Common\CreditCard;
 use Omnipay\PayPal\Message\ExpressAuthorizeRequest;
 use Omnipay\PayPal\Support\InstantUpdateApi\ShippingOption;
-use Omnipay\Tests\TestCase;
+use League\Omnipay\Tests\TestCase;
 
 class ExpressAuthorizeRequestTest extends TestCase
 {
@@ -306,7 +306,7 @@ class ExpressAuthorizeRequestTest extends TestCase
         )));
 
         $this->setExpectedException(
-            '\Omnipay\Common\Exception\InvalidRequestException',
+            '\League\Omnipay\Common\Exception\InvalidRequestException',
             'One of the supplied shipping options must be set as default'
         );
 
@@ -321,7 +321,7 @@ class ExpressAuthorizeRequestTest extends TestCase
         $this->request->initialize($baseData);
 
         $this->setExpectedException(
-            '\Omnipay\Common\Exception\InvalidRequestException',
+            '\League\Omnipay\Common\Exception\InvalidRequestException',
             'The amount parameter is required'
         );
 
@@ -337,7 +337,7 @@ class ExpressAuthorizeRequestTest extends TestCase
         $this->request->initialize($baseData);
 
         $this->setExpectedException(
-            '\Omnipay\Common\Exception\InvalidRequestException',
+            '\League\Omnipay\Common\Exception\InvalidRequestException',
             'The returnUrl parameter is required'
         );
 
@@ -367,7 +367,7 @@ class ExpressAuthorizeRequestTest extends TestCase
         // from the docblock on this exception -
         // Thrown when a request is invalid or missing required fields.
         // callback has been set but no shipping options so expect one of these:
-        $this->setExpectedException('\Omnipay\Common\Exception\InvalidRequestException');
+        $this->setExpectedException('\League\Omnipay\Common\Exception\InvalidRequestException');
 
         $this->request->getData();
     }

--- a/tests/Message/ExpressAuthorizeResponseTest.php
+++ b/tests/Message/ExpressAuthorizeResponseTest.php
@@ -2,7 +2,7 @@
 
 namespace Omnipay\PayPal\Message;
 
-use Omnipay\Tests\TestCase;
+use League\Omnipay\Tests\TestCase;
 use Omnipay\PayPal\Message\ExpressAuthorizeResponse;
 
 class ExpressAuthorizeResponseTest extends TestCase

--- a/tests/Message/ExpressCompleteAuthorizeRequestTest.php
+++ b/tests/Message/ExpressCompleteAuthorizeRequestTest.php
@@ -15,10 +15,12 @@ class ExpressCompleteAuthorizeRequestTest extends TestCase
     public function setUp()
     {
         $client = $this->getHttpClient();
-
         $request = $this->getHttpRequest();
-        $request->query->set('PayerID', 'Payer-1234');
-        $request->query->set('token', 'TOKEN1234');
+
+        $query = $request->getQueryParams();
+        $query['PayerID'] = 'Payer-1234';
+        $query['token'] = 'TOKEN1234';
+        $request = $request->withQueryParams($query);
 
         $this->request = new ExpressCompleteAuthorizeRequest($client, $request);
     }

--- a/tests/Message/ExpressCompleteAuthorizeRequestTest.php
+++ b/tests/Message/ExpressCompleteAuthorizeRequestTest.php
@@ -3,7 +3,7 @@
 namespace Omnipay\PayPal\Message;
 
 use Omnipay\PayPal\Message\ExpressCompleteAuthorizeRequest;
-use Omnipay\Tests\TestCase;
+use League\Omnipay\Tests\TestCase;
 
 class ExpressCompleteAuthorizeRequestTest extends TestCase
 {

--- a/tests/Message/ExpressCompletePurchaseRequestTest.php
+++ b/tests/Message/ExpressCompletePurchaseRequestTest.php
@@ -3,7 +3,7 @@
 namespace Omnipay\PayPal\Message;
 
 use Omnipay\PayPal\Message\ExpressCompletePurchaseRequest;
-use Omnipay\Tests\TestCase;
+use League\Omnipay\Tests\TestCase;
 
 class ExpressCompletePurchaseRequestTest extends TestCase
 {

--- a/tests/Message/ExpressCompletePurchaseRequestTest.php
+++ b/tests/Message/ExpressCompletePurchaseRequestTest.php
@@ -15,10 +15,12 @@ class ExpressCompletePurchaseRequestTest extends TestCase
     public function setUp()
     {
         $client = $this->getHttpClient();
-
         $request = $this->getHttpRequest();
-        $request->query->set('PayerID', 'Payer-1234');
-        $request->query->set('token', 'TOKEN1234');
+
+        $query = $request->getQueryParams();
+        $query['PayerID'] = 'Payer-1234';
+        $query['token'] = 'TOKEN1234';
+        $request = $request->withQueryParams($query);
 
         $this->request = new ExpressCompletePurchaseRequest($client, $request);
     }

--- a/tests/Message/ExpressFetchCheckoutRequestTest.php
+++ b/tests/Message/ExpressFetchCheckoutRequestTest.php
@@ -15,9 +15,11 @@ class ExpressFetchCheckoutRequestTest extends TestCase
     public function setUp()
     {
         $client = $this->getHttpClient();
-
         $request = $this->getHttpRequest();
-        $request->query->set('token', 'TOKEN1234');
+
+        $query = $request->getQueryParams();
+        $query['token'] = 'TOKEN1234';
+        $request = $request->withQueryParams($query);
 
         $this->request = new ExpressFetchCheckoutRequest($client, $request);
     }

--- a/tests/Message/ExpressFetchCheckoutRequestTest.php
+++ b/tests/Message/ExpressFetchCheckoutRequestTest.php
@@ -3,7 +3,7 @@
 namespace Omnipay\PayPal\Message;
 
 use Omnipay\PayPal\Message\ExpressFetchCheckoutRequest;
-use Omnipay\Tests\TestCase;
+use League\Omnipay\Tests\TestCase;
 
 class ExpressFetchCheckoutRequestTest extends TestCase
 {

--- a/tests/Message/ExpressInContextAuthorizeRequestTest.php
+++ b/tests/Message/ExpressInContextAuthorizeRequestTest.php
@@ -2,10 +2,10 @@
 
 namespace Omnipay\PayPal\Message;
 
-use Omnipay\Common\CreditCard;
+use League\Omnipay\Common\CreditCard;
 use Omnipay\PayPal\Message\ExpressInContextAuthorizeRequest;
 use Omnipay\PayPal\Support\InstantUpdateApi\ShippingOption;
-use Omnipay\Tests\TestCase;
+use League\Omnipay\Tests\TestCase;
 
 class ExpressInContextAuthorizeRequestTest extends TestCase
 {
@@ -306,7 +306,7 @@ class ExpressInContextAuthorizeRequestTest extends TestCase
         )));
 
         $this->setExpectedException(
-            '\Omnipay\Common\Exception\InvalidRequestException',
+            '\League\Omnipay\Common\Exception\InvalidRequestException',
             'One of the supplied shipping options must be set as default'
         );
 
@@ -321,7 +321,7 @@ class ExpressInContextAuthorizeRequestTest extends TestCase
         $this->request->initialize($baseData);
 
         $this->setExpectedException(
-            '\Omnipay\Common\Exception\InvalidRequestException',
+            '\League\Omnipay\Common\Exception\InvalidRequestException',
             'The amount parameter is required'
         );
 
@@ -337,7 +337,7 @@ class ExpressInContextAuthorizeRequestTest extends TestCase
         $this->request->initialize($baseData);
 
         $this->setExpectedException(
-            '\Omnipay\Common\Exception\InvalidRequestException',
+            '\League\Omnipay\Common\Exception\InvalidRequestException',
             'The returnUrl parameter is required'
         );
 
@@ -367,7 +367,7 @@ class ExpressInContextAuthorizeRequestTest extends TestCase
         // from the docblock on this exception -
         // Thrown when a request is invalid or missing required fields.
         // callback has been set but no shipping options so expect one of these:
-        $this->setExpectedException('\Omnipay\Common\Exception\InvalidRequestException');
+        $this->setExpectedException('\League\Omnipay\Common\Exception\InvalidRequestException');
 
         $this->request->getData();
     }

--- a/tests/Message/ExpressInContextAuthorizeRequestTest.php
+++ b/tests/Message/ExpressInContextAuthorizeRequestTest.php
@@ -3,6 +3,7 @@
 namespace Omnipay\PayPal\Message;
 
 use League\Omnipay\Common\CreditCard;
+use League\Omnipay\Common\Customer;
 use Omnipay\PayPal\Message\ExpressInContextAuthorizeRequest;
 use Omnipay\PayPal\Support\InstantUpdateApi\ShippingOption;
 use League\Omnipay\Tests\TestCase;
@@ -29,7 +30,7 @@ class ExpressInContextAuthorizeRequestTest extends TestCase
         );
     }
 
-    public function testGetDataWithoutCard()
+    public function testGetDataWithoutCustomer()
     {
         $this->request->initialize(array(
             'amount' => '10.00',
@@ -66,7 +67,7 @@ class ExpressInContextAuthorizeRequestTest extends TestCase
         $this->assertSame('1-801-FLOWERS', $data['CUSTOMERSERVICENUMBER']);
     }
 
-    public function testGetDataWithCard()
+    public function testGetDataWithCustomer()
     {
         $this->request->initialize(array(
             'amount' => '10.00',
@@ -89,7 +90,7 @@ class ExpressInContextAuthorizeRequestTest extends TestCase
             'sellerPaypalAccountId' => 'billing@example.com',
         ));
 
-        $card = new CreditCard(array(
+        $customer = new Customer(array(
             'name' => 'John Doe',
             'address1' => '123 NW Blvd',
             'address2' => 'Lynx Lane',
@@ -100,7 +101,7 @@ class ExpressInContextAuthorizeRequestTest extends TestCase
             'phone' => '555-555-5555',
             'email' => 'test@email.com',
         ));
-        $this->request->setCard($card);
+        $this->request->setCustomer($customer);
 
         $expected = array(
             'METHOD' => 'SetExpressCheckout',

--- a/tests/Message/ExpressInContextAuthorizeRequestTest.php
+++ b/tests/Message/ExpressInContextAuthorizeRequestTest.php
@@ -22,6 +22,7 @@ class ExpressInContextAuthorizeRequestTest extends TestCase
         $this->request->initialize(
             array(
                 'amount' => '10.00',
+                'currency' => 'USD',
                 'returnUrl' => 'https://www.example.com/return',
                 'cancelUrl' => 'https://www.example.com/cancel',
             )

--- a/tests/Message/ExpressInContextAuthorizeResponseTest.php
+++ b/tests/Message/ExpressInContextAuthorizeResponseTest.php
@@ -2,7 +2,7 @@
 
 namespace Omnipay\PayPal\Message;
 
-use Omnipay\Tests\TestCase;
+use League\Omnipay\Tests\TestCase;
 use Omnipay\PayPal\Message\ExpressInContextAuthorizeResponse;
 
 class ExpressInContextAuthorizeResponseTest extends TestCase

--- a/tests/Message/ExpressTransactionSearchRequestTest.php
+++ b/tests/Message/ExpressTransactionSearchRequestTest.php
@@ -2,7 +2,7 @@
 
 namespace Omnipay\PayPal\Message;
 
-use Omnipay\Tests\TestCase;
+use League\Omnipay\Tests\TestCase;
 
 class ExpressTransactionSearchRequestTest extends TestCase
 {
@@ -74,7 +74,7 @@ class ExpressTransactionSearchRequestTest extends TestCase
         $this->request->initialize(array());
 
         $this->setExpectedException(
-            '\Omnipay\Common\Exception\InvalidRequestException',
+            '\League\Omnipay\Common\Exception\InvalidRequestException',
             'The startDate parameter is required'
         );
 
@@ -87,7 +87,7 @@ class ExpressTransactionSearchRequestTest extends TestCase
         $this->request->setAmount(150.00);
 
         $this->setExpectedException(
-            '\Omnipay\Common\Exception\InvalidRequestException',
+            '\League\Omnipay\Common\Exception\InvalidRequestException',
             'The currency parameter is required'
         );
 

--- a/tests/Message/ExpressTransactionSearchRequestTest.php
+++ b/tests/Message/ExpressTransactionSearchRequestTest.php
@@ -88,7 +88,7 @@ class ExpressTransactionSearchRequestTest extends TestCase
 
         $this->setExpectedException(
             '\League\Omnipay\Common\Exception\InvalidRequestException',
-            'The currency parameter is required'
+            'A currency is required.'
         );
 
         $this->request->getData();

--- a/tests/Message/ExpressTransactionSearchResponseTest.php
+++ b/tests/Message/ExpressTransactionSearchResponseTest.php
@@ -2,7 +2,7 @@
 
 namespace Omnipay\PayPal\Message;
 
-use Omnipay\Tests\TestCase;
+use League\Omnipay\Tests\TestCase;
 
 class ExpressTransactionSearchResponseTest extends TestCase
 {

--- a/tests/Message/ExpressVoidRequestTest.php
+++ b/tests/Message/ExpressVoidRequestTest.php
@@ -2,8 +2,8 @@
 
 namespace Omnipay\PayPal\Message;
 
-use Omnipay\Common\CreditCard;
-use Omnipay\Tests\TestCase;
+use League\Omnipay\Common\CreditCard;
+use League\Omnipay\Tests\TestCase;
 
 class ExpressVoidRequestTest extends TestCase
 {

--- a/tests/Message/FetchTransactionRequestTest.php
+++ b/tests/Message/FetchTransactionRequestTest.php
@@ -3,7 +3,7 @@
 namespace Omnipay\PayPal\Message;
 
 use Omnipay\PayPal\Message\FetchTransactionRequest;
-use Omnipay\Tests\TestCase;
+use League\Omnipay\Tests\TestCase;
 
 class FetchTransactionRequestTest extends TestCase
 {

--- a/tests/Message/ProAuthorizeRequestTest.php
+++ b/tests/Message/ProAuthorizeRequestTest.php
@@ -3,6 +3,7 @@
 namespace Omnipay\PayPal\Message;
 
 use League\Omnipay\Common\CreditCard;
+use League\Omnipay\Common\Customer;
 use League\Omnipay\Tests\TestCase;
 
 class ProAuthorizeRequestTest extends TestCase
@@ -22,6 +23,7 @@ class ProAuthorizeRequestTest extends TestCase
                 'amount' => '10.00',
                 'currency' => 'USD',
                 'card' => $this->getValidCard(),
+                'customer' => $this->getCustomer(),
             )
         );
     }
@@ -32,7 +34,10 @@ class ProAuthorizeRequestTest extends TestCase
         $card->setStartMonth(1);
         $card->setStartYear(2000);
 
+        $customer = new Customer($this->getCustomer());
+
         $this->request->setCard($card);
+        $this->request->setCustomer($customer);
         $this->request->setTransactionId('abc123');
         $this->request->setDescription('Sheep');
         $this->request->setClientIp('127.0.0.1');
@@ -54,14 +59,14 @@ class ProAuthorizeRequestTest extends TestCase
         $this->assertSame($card->getCvv(), $data['CVV2']);
         $this->assertSame($card->getIssueNumber(), $data['ISSUENUMBER']);
 
-        $this->assertSame($card->getFirstName(), $data['FIRSTNAME']);
-        $this->assertSame($card->getLastName(), $data['LASTNAME']);
-        $this->assertSame($card->getEmail(), $data['EMAIL']);
-        $this->assertSame($card->getAddress1(), $data['STREET']);
-        $this->assertSame($card->getAddress2(), $data['STREET2']);
-        $this->assertSame($card->getCity(), $data['CITY']);
-        $this->assertSame($card->getState(), $data['STATE']);
-        $this->assertSame($card->getPostcode(), $data['ZIP']);
-        $this->assertSame($card->getCountry(), $data['COUNTRYCODE']);
+        $this->assertSame($customer->getFirstName(), $data['FIRSTNAME']);
+        $this->assertSame($customer->getLastName(), $data['LASTNAME']);
+        $this->assertSame($customer->getEmail(), $data['EMAIL']);
+        $this->assertSame($customer->getAddress1(), $data['STREET']);
+        $this->assertSame($customer->getAddress2(), $data['STREET2']);
+        $this->assertSame($customer->getCity(), $data['CITY']);
+        $this->assertSame($customer->getState(), $data['STATE']);
+        $this->assertSame($customer->getPostcode(), $data['ZIP']);
+        $this->assertSame($customer->getCountry(), $data['COUNTRYCODE']);
     }
 }

--- a/tests/Message/ProAuthorizeRequestTest.php
+++ b/tests/Message/ProAuthorizeRequestTest.php
@@ -2,8 +2,8 @@
 
 namespace Omnipay\PayPal\Message;
 
-use Omnipay\Common\CreditCard;
-use Omnipay\Tests\TestCase;
+use League\Omnipay\Common\CreditCard;
+use League\Omnipay\Tests\TestCase;
 
 class ProAuthorizeRequestTest extends TestCase
 {

--- a/tests/Message/ProPurchaseRequestTest.php
+++ b/tests/Message/ProPurchaseRequestTest.php
@@ -2,8 +2,8 @@
 
 namespace Omnipay\PayPal\Message;
 
-use Omnipay\Common\CreditCard;
-use Omnipay\Tests\TestCase;
+use League\Omnipay\Common\CreditCard;
+use League\Omnipay\Tests\TestCase;
 
 class ProPurchaseRequestTest extends TestCase
 {

--- a/tests/Message/ProPurchaseRequestTest.php
+++ b/tests/Message/ProPurchaseRequestTest.php
@@ -3,6 +3,7 @@
 namespace Omnipay\PayPal\Message;
 
 use League\Omnipay\Common\CreditCard;
+use League\Omnipay\Common\Customer;
 use League\Omnipay\Tests\TestCase;
 
 class ProPurchaseRequestTest extends TestCase
@@ -22,6 +23,7 @@ class ProPurchaseRequestTest extends TestCase
                 'amount' => '10.00',
                 'currency' => 'USD',
                 'card' => $this->getValidCard(),
+                'customer'  => $this->getCustomer(),
             )
         );
     }
@@ -32,7 +34,10 @@ class ProPurchaseRequestTest extends TestCase
         $card->setStartMonth(1);
         $card->setStartYear(2000);
 
+        $customer = new Customer($this->getCustomer());
+
         $this->request->setCard($card);
+        $this->request->setCustomer($customer);
         $this->request->setTransactionId('abc123');
         $this->request->setDescription('Sheep');
         $this->request->setClientIp('127.0.0.1');
@@ -54,14 +59,14 @@ class ProPurchaseRequestTest extends TestCase
         $this->assertSame($card->getCvv(), $data['CVV2']);
         $this->assertSame($card->getIssueNumber(), $data['ISSUENUMBER']);
 
-        $this->assertSame($card->getFirstName(), $data['FIRSTNAME']);
-        $this->assertSame($card->getLastName(), $data['LASTNAME']);
-        $this->assertSame($card->getEmail(), $data['EMAIL']);
-        $this->assertSame($card->getAddress1(), $data['STREET']);
-        $this->assertSame($card->getAddress2(), $data['STREET2']);
-        $this->assertSame($card->getCity(), $data['CITY']);
-        $this->assertSame($card->getState(), $data['STATE']);
-        $this->assertSame($card->getPostcode(), $data['ZIP']);
-        $this->assertSame($card->getCountry(), $data['COUNTRYCODE']);
+        $this->assertSame($customer->getFirstName(), $data['FIRSTNAME']);
+        $this->assertSame($customer->getLastName(), $data['LASTNAME']);
+        $this->assertSame($customer->getEmail(), $data['EMAIL']);
+        $this->assertSame($customer->getAddress1(), $data['STREET']);
+        $this->assertSame($customer->getAddress2(), $data['STREET2']);
+        $this->assertSame($customer->getCity(), $data['CITY']);
+        $this->assertSame($customer->getState(), $data['STATE']);
+        $this->assertSame($customer->getPostcode(), $data['ZIP']);
+        $this->assertSame($customer->getCountry(), $data['COUNTRYCODE']);
     }
 }

--- a/tests/Message/RefundRequestTest.php
+++ b/tests/Message/RefundRequestTest.php
@@ -3,7 +3,7 @@
 namespace Omnipay\PayPal\Message;
 
 use Omnipay\PayPal\Message\RefundRequest;
-use Omnipay\Tests\TestCase;
+use League\Omnipay\Tests\TestCase;
 
 class RefundRequestTest extends TestCase
 {

--- a/tests/Message/ResponseTest.php
+++ b/tests/Message/ResponseTest.php
@@ -2,7 +2,7 @@
 
 namespace Omnipay\PayPal\Message;
 
-use Omnipay\Tests\TestCase;
+use League\Omnipay\Tests\TestCase;
 
 class ResponseTest extends TestCase
 {

--- a/tests/Message/RestAuthorizeRequestTest.php
+++ b/tests/Message/RestAuthorizeRequestTest.php
@@ -3,6 +3,7 @@
 namespace Omnipay\PayPal\Message;
 
 use League\Omnipay\Common\CreditCard;
+use League\Omnipay\Common\Customer;
 use League\Omnipay\Tests\TestCase;
 
 class RestAuthorizeRequestTest extends TestCase
@@ -53,7 +54,10 @@ class RestAuthorizeRequestTest extends TestCase
         $card->setStartMonth(1);
         $card->setStartYear(2000);
 
+        $customer = new Customer($this->getCustomer());
+
         $this->request->setCard($card);
+        $this->request->setCustomer($customer);
         $this->request->setTransactionId('abc123');
         $this->request->setDescription('Sheep');
         $this->request->setClientIp('127.0.0.1');
@@ -72,14 +76,14 @@ class RestAuthorizeRequestTest extends TestCase
         $this->assertSame($card->getExpiryYear(), $data['payer']['funding_instruments'][0]['credit_card']['expire_year']);
         $this->assertSame($card->getCvv(), $data['payer']['funding_instruments'][0]['credit_card']['cvv2']);
 
-        $this->assertSame($card->getFirstName(), $data['payer']['funding_instruments'][0]['credit_card']['first_name']);
-        $this->assertSame($card->getLastName(), $data['payer']['funding_instruments'][0]['credit_card']['last_name']);
-        $this->assertSame($card->getAddress1(), $data['payer']['funding_instruments'][0]['credit_card']['billing_address']['line1']);
-        $this->assertSame($card->getAddress2(), $data['payer']['funding_instruments'][0]['credit_card']['billing_address']['line2']);
-        $this->assertSame($card->getCity(), $data['payer']['funding_instruments'][0]['credit_card']['billing_address']['city']);
-        $this->assertSame($card->getState(), $data['payer']['funding_instruments'][0]['credit_card']['billing_address']['state']);
-        $this->assertSame($card->getPostcode(), $data['payer']['funding_instruments'][0]['credit_card']['billing_address']['postal_code']);
-        $this->assertSame($card->getCountry(), $data['payer']['funding_instruments'][0]['credit_card']['billing_address']['country_code']);
+        $this->assertSame($customer->getFirstName(), $data['payer']['funding_instruments'][0]['credit_card']['first_name']);
+        $this->assertSame($customer->getLastName(), $data['payer']['funding_instruments'][0]['credit_card']['last_name']);
+        $this->assertSame($customer->getAddress1(), $data['payer']['funding_instruments'][0]['credit_card']['billing_address']['line1']);
+        $this->assertSame($customer->getAddress2(), $data['payer']['funding_instruments'][0]['credit_card']['billing_address']['line2']);
+        $this->assertSame($customer->getCity(), $data['payer']['funding_instruments'][0]['credit_card']['billing_address']['city']);
+        $this->assertSame($customer->getState(), $data['payer']['funding_instruments'][0]['credit_card']['billing_address']['state']);
+        $this->assertSame($customer->getPostcode(), $data['payer']['funding_instruments'][0]['credit_card']['billing_address']['postal_code']);
+        $this->assertSame($customer->getCountry(), $data['payer']['funding_instruments'][0]['credit_card']['billing_address']['country_code']);
     }
 
     public function testGetDataWithItems()

--- a/tests/Message/RestAuthorizeRequestTest.php
+++ b/tests/Message/RestAuthorizeRequestTest.php
@@ -9,7 +9,7 @@ use League\Omnipay\Tests\TestCase;
 class RestAuthorizeRequestTest extends TestCase
 {
     /**
-     * @var ProPurchaseRequest
+     * @var RestAuthorizeRequest
      */
     private $request;
 

--- a/tests/Message/RestAuthorizeRequestTest.php
+++ b/tests/Message/RestAuthorizeRequestTest.php
@@ -2,8 +2,8 @@
 
 namespace Omnipay\PayPal\Message;
 
-use Omnipay\Common\CreditCard;
-use Omnipay\Tests\TestCase;
+use League\Omnipay\Common\CreditCard;
+use League\Omnipay\Tests\TestCase;
 
 class RestAuthorizeRequestTest extends TestCase
 {

--- a/tests/Message/RestAuthorizeResponseTest.php
+++ b/tests/Message/RestAuthorizeResponseTest.php
@@ -4,7 +4,7 @@
 namespace Omnipay\PayPal\Message;
 
 
-use Omnipay\Tests\TestCase;
+use League\Omnipay\Tests\TestCase;
 
 class RestAuthorizeResponseTest extends TestCase
 {

--- a/tests/Message/RestAuthorizeResponseTest.php
+++ b/tests/Message/RestAuthorizeResponseTest.php
@@ -11,7 +11,11 @@ class RestAuthorizeResponseTest extends TestCase
     public function testRestPurchaseWithoutCardSuccess()
     {
         $httpResponse = $this->getMockHttpResponse('RestPurchaseWithoutCardSuccess.txt');
-        $response = new RestAuthorizeResponse($this->getMockRequest(), $httpResponse->json(), $httpResponse->getStatusCode());
+        $response = new RestAuthorizeResponse(
+            $this->getMockRequest(),
+            json_decode($httpResponse->getBody()->getContents(), true),
+            $httpResponse->getStatusCode()
+        );
 
         $this->assertTrue($response->isSuccessful());
         $this->assertSame('PAY-3TJ47806DA028052TKTQGVYI', $response->getTransactionReference());

--- a/tests/Message/RestCancelSubscriptionRequestTest.php
+++ b/tests/Message/RestCancelSubscriptionRequestTest.php
@@ -2,7 +2,7 @@
 
 namespace Omnipay\PayPal\Message;
 
-use Omnipay\Tests\TestCase;
+use League\Omnipay\Tests\TestCase;
 use Omnipay\PayPal\RestGateway;
 
 class RestCancelSubscriptionRequestTest extends TestCase

--- a/tests/Message/RestCompletePurchaseRequestTest.php
+++ b/tests/Message/RestCompletePurchaseRequestTest.php
@@ -4,7 +4,7 @@
 namespace Omnipay\PayPal\Message;
 
 
-use Omnipay\Tests\TestCase;
+use League\Omnipay\Tests\TestCase;
 
 class RestCompletePurchaseRequestTest extends TestCase
 {

--- a/tests/Message/RestCompleteSubscriptionRequestTest.php
+++ b/tests/Message/RestCompleteSubscriptionRequestTest.php
@@ -2,7 +2,7 @@
 
 namespace Omnipay\PayPal\Message;
 
-use Omnipay\Tests\TestCase;
+use League\Omnipay\Tests\TestCase;
 use Omnipay\PayPal\RestGateway;
 
 class RestCompleteSubscriptionRequestTest extends TestCase

--- a/tests/Message/RestCreateCardRequestTest.php
+++ b/tests/Message/RestCreateCardRequestTest.php
@@ -2,8 +2,8 @@
 
 namespace Omnipay\PayPal\Message;
 
-use Omnipay\Common\CreditCard;
-use Omnipay\Tests\TestCase;
+use League\Omnipay\Common\CreditCard;
+use League\Omnipay\Tests\TestCase;
 
 class RestCreateCardRequestTest extends TestCase
 {

--- a/tests/Message/RestCreateCardRequestTest.php
+++ b/tests/Message/RestCreateCardRequestTest.php
@@ -3,6 +3,7 @@
 namespace Omnipay\PayPal\Message;
 
 use League\Omnipay\Common\CreditCard;
+use League\Omnipay\Common\Customer;
 use League\Omnipay\Tests\TestCase;
 
 class RestCreateCardRequestTest extends TestCase
@@ -13,6 +14,9 @@ class RestCreateCardRequestTest extends TestCase
     /** @var CreditCard */
     protected $card;
 
+    /** @var Customer */
+    protected $customer;
+
     public function setUp()
     {
         parent::setUp();
@@ -21,13 +25,15 @@ class RestCreateCardRequestTest extends TestCase
 
         $card = $this->getValidCard();
         $this->card = new CreditCard($card);
+        $this->customer = new Customer($this->getCustomer());
 
-        $this->request->initialize(array('card' => $card));
+        $this->request->initialize(array('card' => $card, 'customer' => $this->customer));
     }
 
     public function testGetData()
     {
         $card = $this->card;
+        $customer = $this->customer;
         $data = $this->request->getData();
 
         $this->assertSame($card->getNumber(), $data['number']);
@@ -35,13 +41,14 @@ class RestCreateCardRequestTest extends TestCase
         $this->assertSame($card->getExpiryMonth(), $data['expire_month']);
         $this->assertSame($card->getExpiryYear(), $data['expire_year']);
         $this->assertSame($card->getCvv(), $data['cvv2']);
-        $this->assertSame($card->getFirstName(), $data['first_name']);
-        $this->assertSame($card->getLastName(), $data['last_name']);
-        $this->assertSame($card->getAddress1(), $data['billing_address']['line1']);
-        $this->assertSame($card->getAddress2(), $data['billing_address']['line2']);
-        $this->assertSame($card->getCity(), $data['billing_address']['city']);
-        $this->assertSame($card->getState(), $data['billing_address']['state']);
-        $this->assertSame($card->getPostcode(), $data['billing_address']['postal_code']);
-        $this->assertSame($card->getCountry(), $data['billing_address']['country_code']);
+
+        $this->assertSame($customer->getFirstName(), $data['first_name']);
+        $this->assertSame($customer->getLastName(), $data['last_name']);
+        $this->assertSame($customer->getAddress1(), $data['billing_address']['line1']);
+        $this->assertSame($customer->getAddress2(), $data['billing_address']['line2']);
+        $this->assertSame($customer->getCity(), $data['billing_address']['city']);
+        $this->assertSame($customer->getState(), $data['billing_address']['state']);
+        $this->assertSame($customer->getPostcode(), $data['billing_address']['postal_code']);
+        $this->assertSame($customer->getCountry(), $data['billing_address']['country_code']);
     }
 }

--- a/tests/Message/RestCreatePlanRequestTest.php
+++ b/tests/Message/RestCreatePlanRequestTest.php
@@ -2,7 +2,7 @@
 
 namespace Omnipay\PayPal\Message;
 
-use Omnipay\Tests\TestCase;
+use League\Omnipay\Tests\TestCase;
 use Omnipay\PayPal\RestGateway;
 
 class RestCreatePlanRequestTest extends TestCase

--- a/tests/Message/RestCreateSubscriptionRequestTest.php
+++ b/tests/Message/RestCreateSubscriptionRequestTest.php
@@ -2,7 +2,7 @@
 
 namespace Omnipay\PayPal\Message;
 
-use Omnipay\Tests\TestCase;
+use League\Omnipay\Tests\TestCase;
 use Omnipay\PayPal\RestGateway;
 
 class RestCreateSubscriptionRequestTest extends TestCase

--- a/tests/Message/RestDeleteCardRequestTest.php
+++ b/tests/Message/RestDeleteCardRequestTest.php
@@ -2,8 +2,8 @@
 
 namespace Omnipay\PayPal\Message;
 
-use Omnipay\Common\CreditCard;
-use Omnipay\Tests\TestCase;
+use League\Omnipay\Common\CreditCard;
+use League\Omnipay\Tests\TestCase;
 
 class RestDeleteCardRequestTest extends TestCase
 {

--- a/tests/Message/RestFetchPurchaseRequestTest.php
+++ b/tests/Message/RestFetchPurchaseRequestTest.php
@@ -2,7 +2,7 @@
 
 namespace Omnipay\PayPal\Message;
 
-use Omnipay\Tests\TestCase;
+use League\Omnipay\Tests\TestCase;
 
 class RestFetchPurchaseRequestTest extends TestCase
 {

--- a/tests/Message/RestFetchTransactionRequestTest.php
+++ b/tests/Message/RestFetchTransactionRequestTest.php
@@ -2,7 +2,7 @@
 
 namespace Omnipay\PayPal\Message;
 
-use Omnipay\Tests\TestCase;
+use League\Omnipay\Tests\TestCase;
 
 class RestFetchTransactionRequestTest extends TestCase
 {

--- a/tests/Message/RestPurchaseRequestTest.php
+++ b/tests/Message/RestPurchaseRequestTest.php
@@ -16,11 +16,14 @@ class RestPurchaseRequestTest extends TestCase
         $card->setStartMonth(1);
         $card->setStartYear(2000);
 
+        $customer = $this->getCustomer();
+
         $this->request = new RestPurchaseRequest($this->getHttpClient(), $this->getHttpRequest());
         $this->request->initialize(array(
             'amount' => '10.00',
             'currency' => 'USD',
-            'card' => $card
+            'card' => $card,
+            'customer' => $customer,
         ));
 
         $this->request->setTransactionId('abc123');
@@ -41,14 +44,14 @@ class RestPurchaseRequestTest extends TestCase
         $this->assertSame($card->getExpiryYear(), $data['payer']['funding_instruments'][0]['credit_card']['expire_year']);
         $this->assertSame($card->getCvv(), $data['payer']['funding_instruments'][0]['credit_card']['cvv2']);
 
-        $this->assertSame($card->getFirstName(), $data['payer']['funding_instruments'][0]['credit_card']['first_name']);
-        $this->assertSame($card->getLastName(), $data['payer']['funding_instruments'][0]['credit_card']['last_name']);
-        $this->assertSame($card->getAddress1(), $data['payer']['funding_instruments'][0]['credit_card']['billing_address']['line1']);
-        $this->assertSame($card->getAddress2(), $data['payer']['funding_instruments'][0]['credit_card']['billing_address']['line2']);
-        $this->assertSame($card->getCity(), $data['payer']['funding_instruments'][0]['credit_card']['billing_address']['city']);
-        $this->assertSame($card->getState(), $data['payer']['funding_instruments'][0]['credit_card']['billing_address']['state']);
-        $this->assertSame($card->getPostcode(), $data['payer']['funding_instruments'][0]['credit_card']['billing_address']['postal_code']);
-        $this->assertSame($card->getCountry(), $data['payer']['funding_instruments'][0]['credit_card']['billing_address']['country_code']);
+        $this->assertSame($customer->getFirstName(), $data['payer']['funding_instruments'][0]['credit_card']['first_name']);
+        $this->assertSame($customer->getLastName(), $data['payer']['funding_instruments'][0]['credit_card']['last_name']);
+        $this->assertSame($customer->getAddress1(), $data['payer']['funding_instruments'][0]['credit_card']['billing_address']['line1']);
+        $this->assertSame($customer->getAddress2(), $data['payer']['funding_instruments'][0]['credit_card']['billing_address']['line2']);
+        $this->assertSame($customer->getCity(), $data['payer']['funding_instruments'][0]['credit_card']['billing_address']['city']);
+        $this->assertSame($customer->getState(), $data['payer']['funding_instruments'][0]['credit_card']['billing_address']['state']);
+        $this->assertSame($customer->getPostcode(), $data['payer']['funding_instruments'][0]['credit_card']['billing_address']['postal_code']);
+        $this->assertSame($customer->getCountry(), $data['payer']['funding_instruments'][0]['credit_card']['billing_address']['country_code']);
     }
 
     public function testGetDataWithCardRef()

--- a/tests/Message/RestPurchaseRequestTest.php
+++ b/tests/Message/RestPurchaseRequestTest.php
@@ -2,8 +2,8 @@
 
 namespace Omnipay\PayPal\Message;
 
-use Omnipay\Common\CreditCard;
-use Omnipay\Tests\TestCase;
+use League\Omnipay\Common\CreditCard;
+use League\Omnipay\Tests\TestCase;
 
 class RestPurchaseRequestTest extends TestCase
 {

--- a/tests/Message/RestPurchaseRequestTest.php
+++ b/tests/Message/RestPurchaseRequestTest.php
@@ -3,6 +3,7 @@
 namespace Omnipay\PayPal\Message;
 
 use League\Omnipay\Common\CreditCard;
+use League\Omnipay\Common\Customer;
 use League\Omnipay\Tests\TestCase;
 
 class RestPurchaseRequestTest extends TestCase
@@ -16,7 +17,7 @@ class RestPurchaseRequestTest extends TestCase
         $card->setStartMonth(1);
         $card->setStartYear(2000);
 
-        $customer = $this->getCustomer();
+        $customer = new Customer($this->getCustomer());
 
         $this->request = new RestPurchaseRequest($this->getHttpClient(), $this->getHttpRequest());
         $this->request->initialize(array(

--- a/tests/Message/RestReactivateSubscriptionRequestTest.php
+++ b/tests/Message/RestReactivateSubscriptionRequestTest.php
@@ -2,7 +2,7 @@
 
 namespace Omnipay\PayPal\Message;
 
-use Omnipay\Tests\TestCase;
+use League\Omnipay\Tests\TestCase;
 use Omnipay\PayPal\RestGateway;
 
 class RestReactivateSubscriptionRequestTest extends TestCase

--- a/tests/Message/RestResponseTest.php
+++ b/tests/Message/RestResponseTest.php
@@ -9,7 +9,11 @@ class RestResponseTest extends TestCase
     public function testPurchaseSuccess()
     {
         $httpResponse = $this->getMockHttpResponse('RestPurchaseSuccess.txt');
-        $response = new RestResponse($this->getMockRequest(), $httpResponse->json(), $httpResponse->getStatusCode());
+        $response = new RestResponse(
+            $this->getMockRequest(),
+            json_decode($httpResponse->getBody()->getContents(), true),
+            $httpResponse->getStatusCode()
+        );
 
         $this->assertTrue($response->isSuccessful());
         $this->assertSame('44E89981F8714392Y', $response->getTransactionReference());
@@ -19,7 +23,11 @@ class RestResponseTest extends TestCase
     public function testPurchaseFailure()
     {
         $httpResponse = $this->getMockHttpResponse('RestPurchaseFailure.txt');
-        $response = new RestResponse($this->getMockRequest(), $httpResponse->json(), $httpResponse->getStatusCode());
+        $response = new RestResponse(
+            $this->getMockRequest(),
+            json_decode($httpResponse->getBody()->getContents(), true),
+            $httpResponse->getStatusCode()
+        );
 
         $this->assertFalse($response->isSuccessful());
         $this->assertNull($response->getTransactionReference());
@@ -29,7 +37,11 @@ class RestResponseTest extends TestCase
     public function testCompletePurchaseSuccess()
     {
         $httpResponse = $this->getMockHttpResponse('RestCompletePurchaseSuccess.txt');
-        $response = new RestResponse($this->getMockRequest(), $httpResponse->json(), $httpResponse->getStatusCode());
+        $response = new RestResponse(
+            $this->getMockRequest(),
+            json_decode($httpResponse->getBody()->getContents(), true),
+            $httpResponse->getStatusCode()
+        );
 
         $this->assertTrue($response->isSuccessful());
         $this->assertSame('9EA05739TH369572R', $response->getTransactionReference());
@@ -39,7 +51,11 @@ class RestResponseTest extends TestCase
     public function testCompletePurchaseFailure()
     {
         $httpResponse = $this->getMockHttpResponse('RestCompletePurchaseFailure.txt');
-        $response = new RestResponse($this->getMockRequest(), $httpResponse->json(), $httpResponse->getStatusCode());
+        $response = new RestResponse(
+            $this->getMockRequest(),
+            json_decode($httpResponse->getBody()->getContents(), true),
+            $httpResponse->getStatusCode()
+        );
 
         $this->assertFalse($response->isSuccessful());
         $this->assertNull($response->getTransactionReference());
@@ -49,7 +65,11 @@ class RestResponseTest extends TestCase
     public function testTokenFailure()
     {
         $httpResponse = $this->getMockHttpResponse('RestTokenFailure.txt');
-        $response = new RestResponse($this->getMockRequest(), $httpResponse->json(), $httpResponse->getStatusCode());
+        $response = new RestResponse(
+            $this->getMockRequest(),
+            json_decode($httpResponse->getBody()->getContents(), true),
+            $httpResponse->getStatusCode()
+        );
 
         $this->assertFalse($response->isSuccessful());
         $this->assertSame('Client secret does not match for this client', $response->getMessage());
@@ -58,7 +78,11 @@ class RestResponseTest extends TestCase
     public function testAuthorizeSuccess()
     {
         $httpResponse = $this->getMockHttpResponse('RestAuthorizationSuccess.txt');
-        $response = new RestResponse($this->getMockRequest(), $httpResponse->json(), $httpResponse->getStatusCode());
+        $response = new RestResponse(
+            $this->getMockRequest(),
+            json_decode($httpResponse->getBody()->getContents(), true),
+            $httpResponse->getStatusCode()
+        );
 
         $this->assertTrue($response->isSuccessful());
         $this->assertSame('58N7596879166930B', $response->getTransactionReference());
@@ -68,7 +92,11 @@ class RestResponseTest extends TestCase
     public function testCreateCardSuccess()
     {
         $httpResponse = $this->getMockHttpResponse('RestCreateCardSuccess.txt');
-        $response = new RestResponse($this->getMockRequest(), $httpResponse->json(), $httpResponse->getStatusCode());
+        $response = new RestResponse(
+            $this->getMockRequest(),
+            json_decode($httpResponse->getBody()->getContents(), true),
+            $httpResponse->getStatusCode()
+        );
 
         $this->assertTrue($response->isSuccessful());
         $this->assertSame('CARD-70E78145XN686604FKO3L6OQ', $response->getCardReference());

--- a/tests/Message/RestResponseTest.php
+++ b/tests/Message/RestResponseTest.php
@@ -2,7 +2,7 @@
 
 namespace Omnipay\PayPal\Message;
 
-use Omnipay\Tests\TestCase;
+use League\Omnipay\Tests\TestCase;
 
 class RestResponseTest extends TestCase
 {

--- a/tests/Message/RestSearchTransactionRequestTest.php
+++ b/tests/Message/RestSearchTransactionRequestTest.php
@@ -2,7 +2,7 @@
 
 namespace Omnipay\PayPal\Message;
 
-use Omnipay\Tests\TestCase;
+use League\Omnipay\Tests\TestCase;
 use Omnipay\PayPal\RestGateway;
 
 class RestSearchTransactionRequestTest extends TestCase

--- a/tests/Message/RestSuspendSubscriptionRequestTest.php
+++ b/tests/Message/RestSuspendSubscriptionRequestTest.php
@@ -2,7 +2,7 @@
 
 namespace Omnipay\PayPal\Message;
 
-use Omnipay\Tests\TestCase;
+use League\Omnipay\Tests\TestCase;
 use Omnipay\PayPal\RestGateway;
 
 class RestSuspendSubscriptionRequestTest extends TestCase

--- a/tests/Message/RestUpdatePlanRequestTest.php
+++ b/tests/Message/RestUpdatePlanRequestTest.php
@@ -2,7 +2,7 @@
 
 namespace Omnipay\PayPal\Message;
 
-use Omnipay\Tests\TestCase;
+use League\Omnipay\Tests\TestCase;
 use Omnipay\PayPal\RestGateway;
 
 class RestUpdatePlanRequestTest extends TestCase

--- a/tests/ProGatewayTest.php
+++ b/tests/ProGatewayTest.php
@@ -15,6 +15,7 @@ class ProGatewayTest extends GatewayTestCase
 
         $this->options = array(
             'amount' => '10.00',
+            'currency' => 'USD',
             'card' => new CreditCard(array(
                 'firstName' => 'Example',
                 'lastName' => 'User',

--- a/tests/ProGatewayTest.php
+++ b/tests/ProGatewayTest.php
@@ -17,13 +17,15 @@ class ProGatewayTest extends GatewayTestCase
             'amount' => '10.00',
             'currency' => 'USD',
             'card' => new CreditCard(array(
-                'firstName' => 'Example',
-                'lastName' => 'User',
                 'number' => '4111111111111111',
                 'expiryMonth' => '12',
                 'expiryYear' => '2016',
                 'cvv' => '123',
             )),
+            'customer' => array(
+                'firstName' => 'Example',
+                'lastName' => 'User',
+            )
         );
     }
 

--- a/tests/ProGatewayTest.php
+++ b/tests/ProGatewayTest.php
@@ -2,8 +2,8 @@
 
 namespace Omnipay\PayPal;
 
-use Omnipay\Tests\GatewayTestCase;
-use Omnipay\Common\CreditCard;
+use League\Omnipay\Tests\GatewayTestCase;
+use League\Omnipay\Common\CreditCard;
 
 class ProGatewayTest extends GatewayTestCase
 {

--- a/tests/RestGatewayTest.php
+++ b/tests/RestGatewayTest.php
@@ -26,6 +26,7 @@ class RestGatewayTest extends GatewayTestCase
 
         $this->options = array(
             'amount' => '10.00',
+            'currency' => 'USD',
             'card' => new CreditCard(array(
                 'number' => '4111111111111111',
                 'expiryMonth' => '12',

--- a/tests/RestGatewayTest.php
+++ b/tests/RestGatewayTest.php
@@ -27,13 +27,15 @@ class RestGatewayTest extends GatewayTestCase
         $this->options = array(
             'amount' => '10.00',
             'card' => new CreditCard(array(
-                'firstName' => 'Example',
-                'lastName' => 'User',
                 'number' => '4111111111111111',
                 'expiryMonth' => '12',
                 'expiryYear' => '2016',
                 'cvv' => '123',
             )),
+            'customer' => array(
+                'firstName' => 'Example',
+                'lastName' => 'User',
+            )
         );
 
         $this->subscription_options = array(

--- a/tests/RestGatewayTest.php
+++ b/tests/RestGatewayTest.php
@@ -207,7 +207,11 @@ class RestGatewayTest extends GatewayTestCase
         $cardRef = $response->getCardReference();
 
         $this->setMockHttpResponse('RestPurchaseSuccess.txt');
-        $response = $this->gateway->purchase(array('amount'=>'10.00', 'cardReference'=>$cardRef))->send();
+        $response = $this->gateway->purchase(array(
+            'amount'=>'10.00',
+            'currency' => 'USD',
+            'cardReference'=>$cardRef
+        ))->send();
         $this->assertTrue($response->isSuccessful());
         $this->assertEquals('44E89981F8714392Y', $response->getTransactionReference());
         $this->assertNull($response->getMessage());

--- a/tests/RestGatewayTest.php
+++ b/tests/RestGatewayTest.php
@@ -2,8 +2,8 @@
 
 namespace Omnipay\PayPal;
 
-use Omnipay\Tests\GatewayTestCase;
-use Omnipay\Common\CreditCard;
+use League\Omnipay\Tests\GatewayTestCase;
+use League\Omnipay\Common\CreditCard;
 
 class RestGatewayTest extends GatewayTestCase
 {


### PR DESCRIPTION
This is a test to define an upgrade path and check for problems. The Card + customer split is a bit confusing, because it's difficult to tell where it belongs (customer object in the root of the request options, or as part of shipping/billing in the card?). Together with forcing a currency, these seem to be the biggest end-user changes also.

There are some things to be aware of, like immutability, but the rest should be relative straight forward.

Todo:
- [ ] Make the new `isCompleted()` correct for all cases.
- [ ] Return the correct status codes
- [ ] Return amounts as objects from responses

Notes:

Namespace upgrade:
```php
use Omnipay\Tests\*;
—> 
use League\Omnipay\Tests\*;

use Omnipay\Common\*;
—>
use League\Omnipay\Common\*;
```

Split card + customer objects
Add isCompleted method

Use new HttpClient
 - `array()` instead of `null` for headers argument when empty
 - `getBody()->getContents()` for string value
 - `json_decode($body, true);` instead of `$response->json()`
 - also Encode json send data manually
 - Remove event dispatchers
 ```php
$this->httpRequest->query->get('PayerID')
—>$this->query(‘PayerId’)
```

Use the PSR-7 factories
```php
$httpRequest = $this->httpClient->createRequest(..) 
—> $httpRequest = Factory::createRequest(..)
```

Remove < php5.6 code (search for phpversion())

Use new Amount object for formatting
```php
 - $this->formatCurrency($item->getPrice())
—>
$amount = new Amount($item->getPrice(), $this->getCurrency());
// or
$amount = Amount::fromDecimal($item->getPrice(), $this->getCurrency());

$amount->getFormatted();
```

PSR-7 requests/responses are immutable, so pass new instance to gateway if needed

```php
$this->getHttpRequest()->query->replace(array(     
'token' => 'GET_TOKEN',     
'PayerID' => 'GET_PAYERID', 
)); 
—>
$httpRequest = $this->getHttpRequest();

 $query = $httpRequest->getQueryParams(); 
$query['token'] = 'GET_TOKEN'; $query['PayerID'] = 'GET_PAYERID';  

$httpRequest = $httpRequest->withQueryParams($query);  

$this->gateway = new ExpressGateway($this->getHttpClient(), $httpRequest);
```