### PR TITLE
Add supported ExpressInContext

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ And run composer to update your dependencies:
 The following gateways are provided by this package:
 
 * PayPal_Express (PayPal Express Checkout)
+* PayPal_ExpressInContext (PayPal Express In-Context Checkout)
 * PayPal_Pro (PayPal Website Payments Pro)
 * PayPal_Rest (Paypal Rest API)
 


### PR DESCRIPTION
Adds a note in readme that packages supports In-Context too. See #142 and #144. 