### PR TITLE
 added support for reference transaction in express checkout

### DIFF
--- a/src/Message/ExpressAuthorizeRequest.php
+++ b/src/Message/ExpressAuthorizeRequest.php
@@ -4,6 +4,7 @@ namespace Omnipay\PayPal\Message;
 
 use Omnipay\Common\Exception\InvalidRequestException;
 use Omnipay\PayPal\Support\InstantUpdateApi\ShippingOption;
+use Omnipay\PayPal\Support\InstantUpdateApi\BillingAgreement;
 
 /**
  * PayPal Express Authorize Request
@@ -47,6 +48,22 @@ class ExpressAuthorizeRequest extends AbstractRequest
     public function getShippingOptions()
     {
         return $this->getParameter('shippingOptions');
+    }
+
+    /**
+     * @param BillingAgreement $data
+     */
+    public function setBillingAgreement($data)
+    {
+        $this->setParameter('billingAgreement', $data);
+    }
+
+    /**
+     * @return BillingAgreement
+     */
+    public function getBillingAgreement()
+    {
+        return $this->getParameter('billingAgreement');
     }
 
     protected function validateCallback()
@@ -150,6 +167,20 @@ class ExpressAuthorizeRequest extends AbstractRequest
             $data['PAYMENTREQUEST_0_SHIPTOZIP'] = $card->getPostcode();
             $data['PAYMENTREQUEST_0_SHIPTOPHONENUM'] = $card->getPhone();
             $data['EMAIL'] = $card->getEmail();
+        }
+
+        $billingAgreement = $this->getBillingAgreement();
+        if ($billingAgreement) {
+            $data['L_BILLINGTYPE0'] = $billingAgreement->getType();
+            $data['L_BILLINGAGREEMENTDESCRIPTION0'] = $billingAgreement->getDescription();
+
+            if ($billingAgreement->hasPaymentType()) {
+                $data['L_PAYMENTTYPE0'] = $billingAgreement->getPaymentType();
+            }
+
+            if ($billingAgreement->hasCustomAnnotation()) {
+                $data['L_BILLINGAGREEMENTCUSTOM0'] = $billingAgreement->getCustomAnnotation();
+            }
         }
 
         $data = array_merge($data, $this->getItemData());

--- a/src/Support/InstantUpdateApi/BillingAgreement.php
+++ b/src/Support/InstantUpdateApi/BillingAgreement.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Omnipay\PayPal\Support\InstantUpdateApi;
+
+class BillingAgreement
+{
+    /**
+     * Billing agreement types for single or recurring payment
+     *
+     * @var array
+     */
+    protected $types = [
+        'single' => 'MerchantInitiatedBillingSingleAgreement',
+        'recurring' => 'MerchantInitiatedBilling',
+    ];
+
+    /** @var string */
+    private $type;
+
+    /** @var string */
+    private $description;
+
+    /** @var string */
+    private $paymentType;
+
+    /** @var string */
+    private $customAnnotation;
+
+    /**
+     * @param bool $recurring L_BILLINGTYPE0
+     * @param string $description L_BILLINGAGREEMENTDESCRIPTION0
+     * @param null|string $paymentType L_PAYMENTTYPE0
+     * @param null|string $customAnnotation L_BILLINGAGREEMENTCUSTOM0
+     * @throws \Exception
+     */
+    public function __construct($recurring, $description, $paymentType = null, $customAnnotation = null)
+    {
+        if (!$recurring && !is_null($paymentType) && !in_array($paymentType, ['Any', 'InstantOnly'])) {
+            throw new InvalidRequestException("The 'paymentType' parameter can be only 'Any' or 'InstantOnly'");
+        }
+
+        $this->type = $recurring ? $this->types['recurring'] : $this->types['single'];
+        $this->description = $description;
+        $this->customAnnotation = $customAnnotation;
+        $this->paymentType = $paymentType;
+    }
+
+    /**
+     * @return string
+     */
+    public function getType()
+    {
+        return $this->type;
+    }
+
+    /**
+     * @return string
+     */
+    public function getDescription()
+    {
+        return $this->description;
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasPaymentType()
+    {
+        return !is_null($this->paymentType);
+    }
+
+    /**
+     * @return string
+     */
+    public function getPaymentType()
+    {
+        return $this->paymentType;
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasCustomAnnotation()
+    {
+        return !is_null($this->customAnnotation);
+    }
+
+    /**
+     * @return string
+     */
+    public function getCustomAnnotation()
+    {
+        return $this->customAnnotation;
+    }
+}

--- a/src/Support/InstantUpdateApi/BillingAgreement.php
+++ b/src/Support/InstantUpdateApi/BillingAgreement.php
@@ -2,6 +2,8 @@
 
 namespace Omnipay\PayPal\Support\InstantUpdateApi;
 
+use Omnipay\Common\Exception\InvalidRequestException;
+
 class BillingAgreement
 {
     /**
@@ -9,10 +11,10 @@ class BillingAgreement
      *
      * @var array
      */
-    protected $types = [
+    protected $types = array(
         'single' => 'MerchantInitiatedBillingSingleAgreement',
         'recurring' => 'MerchantInitiatedBilling',
-    ];
+    );
 
     /** @var string */
     private $type;

--- a/src/Support/InstantUpdateApi/BillingAgreement.php
+++ b/src/Support/InstantUpdateApi/BillingAgreement.php
@@ -37,7 +37,7 @@ class BillingAgreement
      */
     public function __construct($recurring, $description, $paymentType = null, $customAnnotation = null)
     {
-        if (!$recurring && !is_null($paymentType) && !in_array($paymentType, ['Any', 'InstantOnly'])) {
+        if (!$recurring && !is_null($paymentType) && !in_array($paymentType, array('Any', 'InstantOnly'))) {
             throw new InvalidRequestException("The 'paymentType' parameter can be only 'Any' or 'InstantOnly'");
         }
 

--- a/tests/Message/ExpressAuthorizeRequestTest.php
+++ b/tests/Message/ExpressAuthorizeRequestTest.php
@@ -417,7 +417,7 @@ class ExpressAuthorizeRequestTest extends TestCase
             '\Omnipay\Common\Exception\InvalidRequestException',
             "The 'paymentType' parameter can be only 'Any' or 'InstantOnly'"
         );
-        
+
         $billingAgreement = new BillingAgreement(false, 'Some Stuff', 'BadType', 'Some custom annotation');
     }
 }

--- a/tests/Message/ExpressAuthorizeRequestTest.php
+++ b/tests/Message/ExpressAuthorizeRequestTest.php
@@ -397,7 +397,7 @@ class ExpressAuthorizeRequestTest extends TestCase
 
     public function testGetDataWithBillingAgreementOptionalParameters()
     {
-        $billingAgreement = new BillingAgreement(true, 'Some Stuff', 'InstantOnly ', 'Some custom annotation');
+        $billingAgreement = new BillingAgreement(true, 'Some Stuff', 'InstantOnly', 'Some custom annotation');
         $this->request->setBillingAgreement($billingAgreement);
 
         $data = $this->request->getData();
@@ -408,13 +408,16 @@ class ExpressAuthorizeRequestTest extends TestCase
         $this->assertSame('Some custom annotation', $data['L_BILLINGAGREEMENTCUSTOM0']);
     }
 
+    /**
+     *
+     */
     public function testGetDataWithBillingAgreementWrongPaymentType()
     {
-        $billingAgreement = new BillingAgreement(true, 'Some Stuff', 'BadType ', 'Some custom annotation');
-
         $this->setExpectedException(
             '\Omnipay\Common\Exception\InvalidRequestException',
             "The 'paymentType' parameter can be only 'Any' or 'InstantOnly'"
         );
+        
+        $billingAgreement = new BillingAgreement(false, 'Some Stuff', 'BadType', 'Some custom annotation');
     }
 }

--- a/tests/ProGatewayTest.php
+++ b/tests/ProGatewayTest.php
@@ -20,7 +20,7 @@ class ProGatewayTest extends GatewayTestCase
                 'lastName' => 'User',
                 'number' => '4111111111111111',
                 'expiryMonth' => '12',
-                'expiryYear' => '2016',
+                'expiryYear' => '2017',
                 'cvv' => '123',
             )),
         );

--- a/tests/RestGatewayTest.php
+++ b/tests/RestGatewayTest.php
@@ -31,7 +31,7 @@ class RestGatewayTest extends GatewayTestCase
                 'lastName' => 'User',
                 'number' => '4111111111111111',
                 'expiryMonth' => '12',
-                'expiryYear' => '2016',
+                'expiryYear' => '2017',
                 'cvv' => '123',
             )),
         );


### PR DESCRIPTION
Refference Transaction is feature of Express Checkout used for recurring payments of varying amounts of money on a varying schedule.

https://developer.paypal.com/docs/classic/express-checkout/integration-guide/ECReferenceTxns/
https://developer.paypal.com/docs/classic/express-checkout/ec_set_up_reference_transactions/