### PR TITLE
Check if is successful based on the response data

### DIFF
--- a/src/Message/ExpressAuthorizeResponse.php
+++ b/src/Message/ExpressAuthorizeResponse.php
@@ -14,12 +14,12 @@ class ExpressAuthorizeResponse extends Response implements RedirectResponseInter
 
     public function isSuccessful()
     {
-        return false;
+        return isset($this->data['ACK']) && in_array($this->data['ACK'], array('Success', 'SuccessWithWarning'));
     }
 
     public function isRedirect()
     {
-        return isset($this->data['ACK']) && in_array($this->data['ACK'], array('Success', 'SuccessWithWarning'));
+        return true;
     }
 
     public function getRedirectUrl()

--- a/tests/ExpressGatewayTest.php
+++ b/tests/ExpressGatewayTest.php
@@ -45,7 +45,7 @@ class ExpressGatewayTest extends GatewayTestCase
 
         $this->assertInstanceOf('\Omnipay\PayPal\Message\ExpressAuthorizeResponse', $response);
         $this->assertFalse($response->isPending());
-        $this->assertFalse($response->isSuccessful());
+        $this->assertTrue($response->isSuccessful());
         $this->assertTrue($response->isRedirect());
         $this->assertEquals('https://www.paypal.com/cgi-bin/webscr?cmd=_express-checkout&useraction=commit&token=EC-42721413K79637829', $response->getRedirectUrl());
     }
@@ -58,7 +58,7 @@ class ExpressGatewayTest extends GatewayTestCase
 
         $this->assertFalse($response->isPending());
         $this->assertFalse($response->isSuccessful());
-        $this->assertFalse($response->isRedirect());
+        $this->assertTrue($response->isRedirect());
         $this->assertNull($response->getTransactionReference());
         $this->assertSame('This transaction cannot be processed. The amount to be charged is zero.', $response->getMessage());
     }
@@ -71,7 +71,7 @@ class ExpressGatewayTest extends GatewayTestCase
 
         $this->assertInstanceOf('\Omnipay\PayPal\Message\ExpressAuthorizeResponse', $response);
         $this->assertFalse($response->isPending());
-        $this->assertFalse($response->isSuccessful());
+        $this->assertTrue($response->isSuccessful());
         $this->assertTrue($response->isRedirect());
         $this->assertEquals('https://www.paypal.com/cgi-bin/webscr?cmd=_express-checkout&useraction=commit&token=EC-42721413K79637829', $response->getRedirectUrl());
     }
@@ -84,7 +84,7 @@ class ExpressGatewayTest extends GatewayTestCase
 
         $this->assertFalse($response->isPending());
         $this->assertFalse($response->isSuccessful());
-        $this->assertFalse($response->isRedirect());
+        $this->assertTrue($response->isRedirect());
         $this->assertNull($response->getTransactionReference());
         $this->assertSame('This transaction cannot be processed. The amount to be charged is zero.', $response->getMessage());
     }
@@ -97,7 +97,7 @@ class ExpressGatewayTest extends GatewayTestCase
 
         $this->assertInstanceOf('\Omnipay\PayPal\Message\ExpressAuthorizeResponse', $response);
         $this->assertFalse($response->isPending());
-        $this->assertFalse($response->isSuccessful());
+        $this->assertTrue($response->isSuccessful());
         $this->assertTrue($response->isRedirect());
         $this->assertEquals('https://www.paypal.com/cgi-bin/webscr?cmd=_express-checkout&useraction=commit&token=EC-42721413K79637829', $response->getRedirectUrl());
     }
@@ -110,7 +110,7 @@ class ExpressGatewayTest extends GatewayTestCase
 
         $this->assertFalse($response->isPending());
         $this->assertFalse($response->isSuccessful());
-        $this->assertFalse($response->isRedirect());
+        $this->assertTrue($response->isRedirect());
         $this->assertNull($response->getTransactionReference());
         $this->assertSame('This transaction cannot be processed. The amount to be charged is zero.', $response->getMessage());
     }

--- a/tests/ExpressInContextGatewayTest.php
+++ b/tests/ExpressInContextGatewayTest.php
@@ -45,7 +45,7 @@ class ExpressInContextGatewayTest extends GatewayTestCase
 
         $this->assertInstanceOf('\Omnipay\PayPal\Message\ExpressInContextAuthorizeResponse', $response);
         $this->assertFalse($response->isPending());
-        $this->assertFalse($response->isSuccessful());
+        $this->assertTrue($response->isSuccessful());
         $this->assertTrue($response->isRedirect());
         $this->assertEquals('https://www.paypal.com/checkoutnow?useraction=commit&token=EC-42721413K79637829', $response->getRedirectUrl());
     }
@@ -58,7 +58,7 @@ class ExpressInContextGatewayTest extends GatewayTestCase
 
         $this->assertInstanceOf('\Omnipay\PayPal\Message\ExpressInContextAuthorizeResponse', $response);
         $this->assertFalse($response->isPending());
-        $this->assertFalse($response->isSuccessful());
+        $this->assertTrue($response->isSuccessful());
         $this->assertTrue($response->isRedirect());
         $this->assertEquals('https://www.paypal.com/checkoutnow?useraction=commit&token=EC-42721413K79637829', $response->getRedirectUrl());
     }
@@ -71,7 +71,7 @@ class ExpressInContextGatewayTest extends GatewayTestCase
 
         $this->assertInstanceOf('\Omnipay\PayPal\Message\ExpressInContextAuthorizeResponse', $response);
         $this->assertFalse($response->isPending());
-        $this->assertFalse($response->isSuccessful());
+        $this->assertTrue($response->isSuccessful());
         $this->assertTrue($response->isRedirect());
         $this->assertEquals('https://www.paypal.com/checkoutnow?useraction=commit&token=EC-42721413K79637829', $response->getRedirectUrl());
     }

--- a/tests/Message/ExpressAuthorizeResponseTest.php
+++ b/tests/Message/ExpressAuthorizeResponseTest.php
@@ -23,7 +23,7 @@ class ExpressAuthorizeResponseTest extends TestCase
         $response = new ExpressAuthorizeResponse($request, $httpResponse->getBody());
 
         $this->assertFalse($response->isPending());
-        $this->assertFalse($response->isSuccessful());
+        $this->asserttrue($response->isSuccessful());
         $this->assertSame('EC-42721413K79637829', $response->getTransactionReference());
         $this->assertNull($response->getMessage());
         $this->assertNull($response->getRedirectData());

--- a/tests/Message/ExpressInContextAuthorizeResponseTest.php
+++ b/tests/Message/ExpressInContextAuthorizeResponseTest.php
@@ -23,7 +23,7 @@ class ExpressInContextAuthorizeResponseTest extends TestCase
         $response = new ExpressInContextAuthorizeResponse($request, $httpResponse->getBody());
 
         $this->assertFalse($response->isPending());
-        $this->assertFalse($response->isSuccessful());
+        $this->assertTrue($response->isSuccessful());
         $this->assertSame('EC-42721413K79637829', $response->getTransactionReference());
         $this->assertNull($response->getMessage());
         $this->assertNull($response->getRedirectData());


### PR DESCRIPTION
Is successful should not always return false, it should return the status of the response based on the data. Is redirect should always return true, because paypal express will always redirect.