### PR TITLE
Ability to partial capture multiple times on same authorization

### DIFF
--- a/src/Message/CaptureRequest.php
+++ b/src/Message/CaptureRequest.php
@@ -16,7 +16,7 @@ class CaptureRequest extends AbstractRequest
         $data['AMT'] = $this->getAmount();
         $data['CURRENCYCODE'] = $this->getCurrency();
         $data['AUTHORIZATIONID'] = $this->getTransactionReference();
-        $data['COMPLETETYPE'] = 'Complete';
+        $data['COMPLETETYPE'] = 'NotComplete';
 
         return $data;
     }

--- a/src/Message/RestCaptureRequest.php
+++ b/src/Message/RestCaptureRequest.php
@@ -48,7 +48,7 @@ class RestCaptureRequest extends AbstractRestRequest
                 'currency' => $this->getCurrency(),
                 'total' => $this->getAmount(),
             ),
-            'is_final_capture' => true,
+            'is_final_capture' => false,
         );
     }
 


### PR DESCRIPTION
These changes allow you to capture the authorization in multiple partial captures. The current code always closes the transaction on the first capture, so no additional captures can occur.