### PR TITLE
Fixed namespaces for Omnipay\Common uses

### DIFF
--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -5,8 +5,8 @@
 
 namespace Omnipay\PayPal\Message;
 
-use League\Omnipay\Common\Amount;
-use League\Omnipay\Common\ItemBag;
+use Omnipay\Common\Amount;
+use Omnipay\Common\ItemBag;
 use Omnipay\PayPal\PayPalItem;
 use Omnipay\PayPal\PayPalItemBag;
 
@@ -33,7 +33,7 @@ use Omnipay\PayPal\PayPalItemBag;
  * @link https://devtools-paypal.com/integrationwizard/
  * @link http://paypal.github.io/sdk/
  */
-abstract class AbstractRequest extends \League\Omnipay\Common\Message\AbstractRequest
+abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
 {
     const API_VERSION = '119.0';
 

--- a/src/Message/AbstractRestRequest.php
+++ b/src/Message/AbstractRestRequest.php
@@ -5,8 +5,8 @@
 
 namespace Omnipay\PayPal\Message;
 
-use League\Omnipay\Common\Exception\InvalidResponseException;
-use League\Omnipay\Common\Http\Factory;
+use Omnipay\Common\Exception\InvalidResponseException;
+use Omnipay\Common\Http\Factory;
 
 /**
  * PayPal Abstract REST Request
@@ -29,7 +29,7 @@ use League\Omnipay\Common\Http\Factory;
  * @link http://paypal.github.io/sdk/
  * @see Omnipay\PayPal\RestGateway
  */
-abstract class AbstractRestRequest extends \League\Omnipay\Common\Message\AbstractRequest
+abstract class AbstractRestRequest extends \Omnipay\Common\Message\AbstractRequest
 {
     const API_VERSION = 'v1';
 

--- a/src/Message/ExpressAuthorizeRequest.php
+++ b/src/Message/ExpressAuthorizeRequest.php
@@ -2,7 +2,7 @@
 
 namespace Omnipay\PayPal\Message;
 
-use League\Omnipay\Common\Exception\InvalidRequestException;
+use Omnipay\Common\Exception\InvalidRequestException;
 use Omnipay\PayPal\Support\InstantUpdateApi\ShippingOption;
 
 /**

--- a/src/Message/ExpressAuthorizeResponse.php
+++ b/src/Message/ExpressAuthorizeResponse.php
@@ -2,7 +2,7 @@
 
 namespace Omnipay\PayPal\Message;
 
-use League\Omnipay\Common\Message\RedirectResponseInterface;
+use Omnipay\Common\Message\RedirectResponseInterface;
 
 /**
  * PayPal Express Authorize Response

--- a/src/Message/ExpressTransactionSearchRequest.php
+++ b/src/Message/ExpressTransactionSearchRequest.php
@@ -108,7 +108,7 @@ class ExpressTransactionSearchRequest extends AbstractRequest
 
     /**
      * @param DateTime|string $date
-     * @return \League\Omnipay\Common\Message\AbstractRequest
+     * @return \Omnipay\Common\Message\AbstractRequest
      */
     public function setStartDate($date)
     {
@@ -129,7 +129,7 @@ class ExpressTransactionSearchRequest extends AbstractRequest
 
     /**
      * @param DateTime|string $date
-     * @return \League\Omnipay\Common\Message\AbstractRequest
+     * @return \Omnipay\Common\Message\AbstractRequest
      */
     public function setEndDate($date)
     {
@@ -150,7 +150,7 @@ class ExpressTransactionSearchRequest extends AbstractRequest
 
     /**
      * @param string $salutation
-     * @return \League\Omnipay\Common\Message\AbstractRequest
+     * @return \Omnipay\Common\Message\AbstractRequest
      */
     public function setSalutation($salutation)
     {
@@ -167,7 +167,7 @@ class ExpressTransactionSearchRequest extends AbstractRequest
 
     /**
      * @param string $firstName
-     * @return \League\Omnipay\Common\Message\AbstractRequest
+     * @return \Omnipay\Common\Message\AbstractRequest
      */
     public function setFirstName($firstName)
     {
@@ -184,7 +184,7 @@ class ExpressTransactionSearchRequest extends AbstractRequest
 
     /**
      * @param string $middleName
-     * @return \League\Omnipay\Common\Message\AbstractRequest
+     * @return \Omnipay\Common\Message\AbstractRequest
      */
     public function setMiddleName($middleName)
     {
@@ -201,7 +201,7 @@ class ExpressTransactionSearchRequest extends AbstractRequest
 
     /**
      * @param string $lastName
-     * @return \League\Omnipay\Common\Message\AbstractRequest
+     * @return \Omnipay\Common\Message\AbstractRequest
      */
     public function setLastName($lastName)
     {
@@ -218,7 +218,7 @@ class ExpressTransactionSearchRequest extends AbstractRequest
 
     /**
      * @param string $suffix
-     * @return \League\Omnipay\Common\Message\AbstractRequest
+     * @return \Omnipay\Common\Message\AbstractRequest
      */
     public function setSuffix($suffix)
     {
@@ -235,7 +235,7 @@ class ExpressTransactionSearchRequest extends AbstractRequest
 
     /**
      * @param string $email
-     * @return \League\Omnipay\Common\Message\AbstractRequest
+     * @return \Omnipay\Common\Message\AbstractRequest
      */
     public function setEmail($email)
     {
@@ -252,7 +252,7 @@ class ExpressTransactionSearchRequest extends AbstractRequest
 
     /**
      * @param string $receiver
-     * @return \League\Omnipay\Common\Message\AbstractRequest
+     * @return \Omnipay\Common\Message\AbstractRequest
      */
     public function setReceiver($receiver)
     {
@@ -269,7 +269,7 @@ class ExpressTransactionSearchRequest extends AbstractRequest
 
     /**
      * @param string $receiptId
-     * @return \League\Omnipay\Common\Message\AbstractRequest
+     * @return \Omnipay\Common\Message\AbstractRequest
      */
     public function setReceiptId($receiptId)
     {
@@ -286,7 +286,7 @@ class ExpressTransactionSearchRequest extends AbstractRequest
 
     /**
      * @param string $invoiceNumber
-     * @return \League\Omnipay\Common\Message\AbstractRequest
+     * @return \Omnipay\Common\Message\AbstractRequest
      */
     public function setInvoiceNumber($invoiceNumber)
     {
@@ -303,7 +303,7 @@ class ExpressTransactionSearchRequest extends AbstractRequest
 
     /**
      * @param string $auctionItemNumber
-     * @return \League\Omnipay\Common\Message\AbstractRequest
+     * @return \Omnipay\Common\Message\AbstractRequest
      */
     public function setAuctionItemNumber($auctionItemNumber)
     {
@@ -320,7 +320,7 @@ class ExpressTransactionSearchRequest extends AbstractRequest
 
     /**
      * @param string $transactionClass
-     * @return \League\Omnipay\Common\Message\AbstractRequest
+     * @return \Omnipay\Common\Message\AbstractRequest
      */
     public function setTransactionClass($transactionClass)
     {
@@ -337,7 +337,7 @@ class ExpressTransactionSearchRequest extends AbstractRequest
 
     /**
      * @param string $status
-     * @return \League\Omnipay\Common\Message\AbstractRequest
+     * @return \Omnipay\Common\Message\AbstractRequest
      */
     public function setStatus($status)
     {
@@ -354,7 +354,7 @@ class ExpressTransactionSearchRequest extends AbstractRequest
 
     /**
      * @param string $profileId
-     * @return \League\Omnipay\Common\Message\AbstractRequest
+     * @return \Omnipay\Common\Message\AbstractRequest
      */
     public function setProfileId($profileId)
     {

--- a/src/Message/ExpressTransactionSearchResponse.php
+++ b/src/Message/ExpressTransactionSearchResponse.php
@@ -2,7 +2,7 @@
 
 namespace Omnipay\PayPal\Message;
 
-use League\Omnipay\Common\Message\RequestInterface;
+use Omnipay\Common\Message\RequestInterface;
 
 /**
  * Response for Transaction Search request

--- a/src/Message/Response.php
+++ b/src/Message/Response.php
@@ -2,8 +2,8 @@
 
 namespace Omnipay\PayPal\Message;
 
-use League\Omnipay\Common\Message\AbstractResponse;
-use League\Omnipay\Common\Message\RequestInterface;
+use Omnipay\Common\Message\AbstractResponse;
+use Omnipay\Common\Message\RequestInterface;
 
 /**
  * PayPal Response

--- a/src/Message/RestAuthorizeRequest.php
+++ b/src/Message/RestAuthorizeRequest.php
@@ -5,7 +5,7 @@
 
 namespace Omnipay\PayPal\Message;
 
-use League\Omnipay\Common\Amount;
+use Omnipay\Common\Amount;
 
 /**
  * PayPal REST Authorize Request

--- a/src/Message/RestAuthorizeResponse.php
+++ b/src/Message/RestAuthorizeResponse.php
@@ -5,7 +5,7 @@
 
 namespace Omnipay\PayPal\Message;
 
-use League\Omnipay\Common\Message\RedirectResponseInterface;
+use Omnipay\Common\Message\RedirectResponseInterface;
 
 /**
  * PayPal REST Authorize Response

--- a/src/Message/RestResponse.php
+++ b/src/Message/RestResponse.php
@@ -5,8 +5,8 @@
 
 namespace Omnipay\PayPal\Message;
 
-use League\Omnipay\Common\Message\AbstractResponse;
-use League\Omnipay\Common\Message\RequestInterface;
+use Omnipay\Common\Message\AbstractResponse;
+use Omnipay\Common\Message\RequestInterface;
 
 /**
  * PayPal REST Response

--- a/src/Message/RestTokenRequest.php
+++ b/src/Message/RestTokenRequest.php
@@ -5,7 +5,7 @@
 
 namespace Omnipay\PayPal\Message;
 
-use League\Omnipay\Common\Http\Factory;
+use Omnipay\Common\Http\Factory;
 
 /**
  * PayPal REST Token Request

--- a/src/PayPalItem.php
+++ b/src/PayPalItem.php
@@ -5,7 +5,7 @@
 
 namespace Omnipay\PayPal;
 
-use League\Omnipay\Common\Item;
+use Omnipay\Common\Item;
 
 /**
  * Class PayPalItem

--- a/src/PayPalItemBag.php
+++ b/src/PayPalItemBag.php
@@ -5,8 +5,8 @@
 
 namespace Omnipay\PayPal;
 
-use League\Omnipay\Common\ItemBag;
-use League\Omnipay\Common\ItemInterface;
+use Omnipay\Common\ItemBag;
+use Omnipay\Common\ItemInterface;
 
 /**
  * Class PayPalItemBag

--- a/src/ProGateway.php
+++ b/src/ProGateway.php
@@ -2,7 +2,7 @@
 
 namespace Omnipay\PayPal;
 
-use League\Omnipay\Common\AbstractGateway;
+use Omnipay\Common\AbstractGateway;
 
 /**
  * PayPal Pro Class

--- a/src/RestGateway.php
+++ b/src/RestGateway.php
@@ -5,7 +5,7 @@
 
 namespace Omnipay\PayPal;
 
-use League\Omnipay\Common\AbstractGateway;
+use Omnipay\Common\AbstractGateway;
 use Omnipay\PayPal\Message\ProAuthorizeRequest;
 use Omnipay\PayPal\Message\CaptureRequest;
 use Omnipay\PayPal\Message\RefundRequest;

--- a/tests/ExpressGatewayTest.php
+++ b/tests/ExpressGatewayTest.php
@@ -2,7 +2,7 @@
 
 namespace Omnipay\PayPal;
 
-use League\Omnipay\Tests\GatewayTestCase;
+use Omnipay\Tests\GatewayTestCase;
 
 class ExpressGatewayTest extends GatewayTestCase
 {

--- a/tests/ExpressInContextGatewayTest.php
+++ b/tests/ExpressInContextGatewayTest.php
@@ -2,7 +2,7 @@
 
 namespace Omnipay\PayPal;
 
-use League\Omnipay\Tests\GatewayTestCase;
+use Omnipay\Tests\GatewayTestCase;
 
 class ExpressInContextGatewayTest extends GatewayTestCase
 {

--- a/tests/Message/CaptureRequestTest.php
+++ b/tests/Message/CaptureRequestTest.php
@@ -3,7 +3,7 @@
 namespace Omnipay\PayPal\Message;
 
 use Omnipay\PayPal\Message\CaptureRequest;
-use League\Omnipay\Tests\TestCase;
+use Omnipay\Tests\TestCase;
 
 class CaptureRequestTest extends TestCase
 {

--- a/tests/Message/ExpressAuthorizeRequestTest.php
+++ b/tests/Message/ExpressAuthorizeRequestTest.php
@@ -2,11 +2,11 @@
 
 namespace Omnipay\PayPal\Message;
 
-use League\Omnipay\Common\CreditCard;
-use League\Omnipay\Common\Customer;
+use Omnipay\Common\CreditCard;
+use Omnipay\Common\Customer;
 use Omnipay\PayPal\Message\ExpressAuthorizeRequest;
 use Omnipay\PayPal\Support\InstantUpdateApi\ShippingOption;
-use League\Omnipay\Tests\TestCase;
+use Omnipay\Tests\TestCase;
 
 class ExpressAuthorizeRequestTest extends TestCase
 {
@@ -308,7 +308,7 @@ class ExpressAuthorizeRequestTest extends TestCase
         )));
 
         $this->setExpectedException(
-            '\League\Omnipay\Common\Exception\InvalidRequestException',
+            '\Omnipay\Common\Exception\InvalidRequestException',
             'One of the supplied shipping options must be set as default'
         );
 
@@ -323,7 +323,7 @@ class ExpressAuthorizeRequestTest extends TestCase
         $this->request->initialize($baseData);
 
         $this->setExpectedException(
-            '\League\Omnipay\Common\Exception\InvalidRequestException',
+            '\Omnipay\Common\Exception\InvalidRequestException',
             'The amount parameter is required'
         );
 
@@ -339,7 +339,7 @@ class ExpressAuthorizeRequestTest extends TestCase
         $this->request->initialize($baseData);
 
         $this->setExpectedException(
-            '\League\Omnipay\Common\Exception\InvalidRequestException',
+            '\Omnipay\Common\Exception\InvalidRequestException',
             'The returnUrl parameter is required'
         );
 
@@ -369,7 +369,7 @@ class ExpressAuthorizeRequestTest extends TestCase
         // from the docblock on this exception -
         // Thrown when a request is invalid or missing required fields.
         // callback has been set but no shipping options so expect one of these:
-        $this->setExpectedException('\League\Omnipay\Common\Exception\InvalidRequestException');
+        $this->setExpectedException('\Omnipay\Common\Exception\InvalidRequestException');
 
         $this->request->getData();
     }

--- a/tests/Message/ExpressAuthorizeResponseTest.php
+++ b/tests/Message/ExpressAuthorizeResponseTest.php
@@ -2,7 +2,7 @@
 
 namespace Omnipay\PayPal\Message;
 
-use League\Omnipay\Tests\TestCase;
+use Omnipay\Tests\TestCase;
 use Omnipay\PayPal\Message\ExpressAuthorizeResponse;
 
 class ExpressAuthorizeResponseTest extends TestCase

--- a/tests/Message/ExpressCompleteAuthorizeRequestTest.php
+++ b/tests/Message/ExpressCompleteAuthorizeRequestTest.php
@@ -3,7 +3,7 @@
 namespace Omnipay\PayPal\Message;
 
 use Omnipay\PayPal\Message\ExpressCompleteAuthorizeRequest;
-use League\Omnipay\Tests\TestCase;
+use Omnipay\Tests\TestCase;
 
 class ExpressCompleteAuthorizeRequestTest extends TestCase
 {

--- a/tests/Message/ExpressCompletePurchaseRequestTest.php
+++ b/tests/Message/ExpressCompletePurchaseRequestTest.php
@@ -3,7 +3,7 @@
 namespace Omnipay\PayPal\Message;
 
 use Omnipay\PayPal\Message\ExpressCompletePurchaseRequest;
-use League\Omnipay\Tests\TestCase;
+use Omnipay\Tests\TestCase;
 
 class ExpressCompletePurchaseRequestTest extends TestCase
 {

--- a/tests/Message/ExpressFetchCheckoutRequestTest.php
+++ b/tests/Message/ExpressFetchCheckoutRequestTest.php
@@ -3,7 +3,7 @@
 namespace Omnipay\PayPal\Message;
 
 use Omnipay\PayPal\Message\ExpressFetchCheckoutRequest;
-use League\Omnipay\Tests\TestCase;
+use Omnipay\Tests\TestCase;
 
 class ExpressFetchCheckoutRequestTest extends TestCase
 {

--- a/tests/Message/ExpressInContextAuthorizeRequestTest.php
+++ b/tests/Message/ExpressInContextAuthorizeRequestTest.php
@@ -2,11 +2,11 @@
 
 namespace Omnipay\PayPal\Message;
 
-use League\Omnipay\Common\CreditCard;
-use League\Omnipay\Common\Customer;
+use Omnipay\Common\CreditCard;
+use Omnipay\Common\Customer;
 use Omnipay\PayPal\Message\ExpressInContextAuthorizeRequest;
 use Omnipay\PayPal\Support\InstantUpdateApi\ShippingOption;
-use League\Omnipay\Tests\TestCase;
+use Omnipay\Tests\TestCase;
 
 class ExpressInContextAuthorizeRequestTest extends TestCase
 {
@@ -308,7 +308,7 @@ class ExpressInContextAuthorizeRequestTest extends TestCase
         )));
 
         $this->setExpectedException(
-            '\League\Omnipay\Common\Exception\InvalidRequestException',
+            '\Omnipay\Common\Exception\InvalidRequestException',
             'One of the supplied shipping options must be set as default'
         );
 
@@ -323,7 +323,7 @@ class ExpressInContextAuthorizeRequestTest extends TestCase
         $this->request->initialize($baseData);
 
         $this->setExpectedException(
-            '\League\Omnipay\Common\Exception\InvalidRequestException',
+            '\Omnipay\Common\Exception\InvalidRequestException',
             'The amount parameter is required'
         );
 
@@ -339,7 +339,7 @@ class ExpressInContextAuthorizeRequestTest extends TestCase
         $this->request->initialize($baseData);
 
         $this->setExpectedException(
-            '\League\Omnipay\Common\Exception\InvalidRequestException',
+            '\Omnipay\Common\Exception\InvalidRequestException',
             'The returnUrl parameter is required'
         );
 
@@ -369,7 +369,7 @@ class ExpressInContextAuthorizeRequestTest extends TestCase
         // from the docblock on this exception -
         // Thrown when a request is invalid or missing required fields.
         // callback has been set but no shipping options so expect one of these:
-        $this->setExpectedException('\League\Omnipay\Common\Exception\InvalidRequestException');
+        $this->setExpectedException('\Omnipay\Common\Exception\InvalidRequestException');
 
         $this->request->getData();
     }

--- a/tests/Message/ExpressInContextAuthorizeResponseTest.php
+++ b/tests/Message/ExpressInContextAuthorizeResponseTest.php
@@ -2,7 +2,7 @@
 
 namespace Omnipay\PayPal\Message;
 
-use League\Omnipay\Tests\TestCase;
+use Omnipay\Tests\TestCase;
 use Omnipay\PayPal\Message\ExpressInContextAuthorizeResponse;
 
 class ExpressInContextAuthorizeResponseTest extends TestCase

--- a/tests/Message/ExpressTransactionSearchRequestTest.php
+++ b/tests/Message/ExpressTransactionSearchRequestTest.php
@@ -2,7 +2,7 @@
 
 namespace Omnipay\PayPal\Message;
 
-use League\Omnipay\Tests\TestCase;
+use Omnipay\Tests\TestCase;
 
 class ExpressTransactionSearchRequestTest extends TestCase
 {
@@ -74,7 +74,7 @@ class ExpressTransactionSearchRequestTest extends TestCase
         $this->request->initialize(array());
 
         $this->setExpectedException(
-            '\League\Omnipay\Common\Exception\InvalidRequestException',
+            '\Omnipay\Common\Exception\InvalidRequestException',
             'The startDate parameter is required'
         );
 
@@ -87,7 +87,7 @@ class ExpressTransactionSearchRequestTest extends TestCase
         $this->request->setAmount(150.00);
 
         $this->setExpectedException(
-            '\League\Omnipay\Common\Exception\InvalidRequestException',
+            '\Omnipay\Common\Exception\InvalidRequestException',
             'A currency is required.'
         );
 

--- a/tests/Message/ExpressTransactionSearchResponseTest.php
+++ b/tests/Message/ExpressTransactionSearchResponseTest.php
@@ -2,7 +2,7 @@
 
 namespace Omnipay\PayPal\Message;
 
-use League\Omnipay\Tests\TestCase;
+use Omnipay\Tests\TestCase;
 
 class ExpressTransactionSearchResponseTest extends TestCase
 {

--- a/tests/Message/ExpressVoidRequestTest.php
+++ b/tests/Message/ExpressVoidRequestTest.php
@@ -2,8 +2,8 @@
 
 namespace Omnipay\PayPal\Message;
 
-use League\Omnipay\Common\CreditCard;
-use League\Omnipay\Tests\TestCase;
+use Omnipay\Common\CreditCard;
+use Omnipay\Tests\TestCase;
 
 class ExpressVoidRequestTest extends TestCase
 {

--- a/tests/Message/FetchTransactionRequestTest.php
+++ b/tests/Message/FetchTransactionRequestTest.php
@@ -3,7 +3,7 @@
 namespace Omnipay\PayPal\Message;
 
 use Omnipay\PayPal\Message\FetchTransactionRequest;
-use League\Omnipay\Tests\TestCase;
+use Omnipay\Tests\TestCase;
 
 class FetchTransactionRequestTest extends TestCase
 {

--- a/tests/Message/ProAuthorizeRequestTest.php
+++ b/tests/Message/ProAuthorizeRequestTest.php
@@ -2,9 +2,9 @@
 
 namespace Omnipay\PayPal\Message;
 
-use League\Omnipay\Common\CreditCard;
-use League\Omnipay\Common\Customer;
-use League\Omnipay\Tests\TestCase;
+use Omnipay\Common\CreditCard;
+use Omnipay\Common\Customer;
+use Omnipay\Tests\TestCase;
 
 class ProAuthorizeRequestTest extends TestCase
 {

--- a/tests/Message/ProPurchaseRequestTest.php
+++ b/tests/Message/ProPurchaseRequestTest.php
@@ -2,9 +2,9 @@
 
 namespace Omnipay\PayPal\Message;
 
-use League\Omnipay\Common\CreditCard;
-use League\Omnipay\Common\Customer;
-use League\Omnipay\Tests\TestCase;
+use Omnipay\Common\CreditCard;
+use Omnipay\Common\Customer;
+use Omnipay\Tests\TestCase;
 
 class ProPurchaseRequestTest extends TestCase
 {

--- a/tests/Message/RefundRequestTest.php
+++ b/tests/Message/RefundRequestTest.php
@@ -3,7 +3,7 @@
 namespace Omnipay\PayPal\Message;
 
 use Omnipay\PayPal\Message\RefundRequest;
-use League\Omnipay\Tests\TestCase;
+use Omnipay\Tests\TestCase;
 
 class RefundRequestTest extends TestCase
 {

--- a/tests/Message/ResponseTest.php
+++ b/tests/Message/ResponseTest.php
@@ -2,7 +2,7 @@
 
 namespace Omnipay\PayPal\Message;
 
-use League\Omnipay\Tests\TestCase;
+use Omnipay\Tests\TestCase;
 
 class ResponseTest extends TestCase
 {

--- a/tests/Message/RestAuthorizeRequestTest.php
+++ b/tests/Message/RestAuthorizeRequestTest.php
@@ -2,9 +2,9 @@
 
 namespace Omnipay\PayPal\Message;
 
-use League\Omnipay\Common\CreditCard;
-use League\Omnipay\Common\Customer;
-use League\Omnipay\Tests\TestCase;
+use Omnipay\Common\CreditCard;
+use Omnipay\Common\Customer;
+use Omnipay\Tests\TestCase;
 
 class RestAuthorizeRequestTest extends TestCase
 {

--- a/tests/Message/RestAuthorizeResponseTest.php
+++ b/tests/Message/RestAuthorizeResponseTest.php
@@ -4,7 +4,7 @@
 namespace Omnipay\PayPal\Message;
 
 
-use League\Omnipay\Tests\TestCase;
+use Omnipay\Tests\TestCase;
 
 class RestAuthorizeResponseTest extends TestCase
 {

--- a/tests/Message/RestCancelSubscriptionRequestTest.php
+++ b/tests/Message/RestCancelSubscriptionRequestTest.php
@@ -2,7 +2,7 @@
 
 namespace Omnipay\PayPal\Message;
 
-use League\Omnipay\Tests\TestCase;
+use Omnipay\Tests\TestCase;
 use Omnipay\PayPal\RestGateway;
 
 class RestCancelSubscriptionRequestTest extends TestCase

--- a/tests/Message/RestCompletePurchaseRequestTest.php
+++ b/tests/Message/RestCompletePurchaseRequestTest.php
@@ -4,7 +4,7 @@
 namespace Omnipay\PayPal\Message;
 
 
-use League\Omnipay\Tests\TestCase;
+use Omnipay\Tests\TestCase;
 
 class RestCompletePurchaseRequestTest extends TestCase
 {

--- a/tests/Message/RestCompleteSubscriptionRequestTest.php
+++ b/tests/Message/RestCompleteSubscriptionRequestTest.php
@@ -2,7 +2,7 @@
 
 namespace Omnipay\PayPal\Message;
 
-use League\Omnipay\Tests\TestCase;
+use Omnipay\Tests\TestCase;
 use Omnipay\PayPal\RestGateway;
 
 class RestCompleteSubscriptionRequestTest extends TestCase

--- a/tests/Message/RestCreateCardRequestTest.php
+++ b/tests/Message/RestCreateCardRequestTest.php
@@ -2,9 +2,9 @@
 
 namespace Omnipay\PayPal\Message;
 
-use League\Omnipay\Common\CreditCard;
-use League\Omnipay\Common\Customer;
-use League\Omnipay\Tests\TestCase;
+use Omnipay\Common\CreditCard;
+use Omnipay\Common\Customer;
+use Omnipay\Tests\TestCase;
 
 class RestCreateCardRequestTest extends TestCase
 {

--- a/tests/Message/RestCreatePlanRequestTest.php
+++ b/tests/Message/RestCreatePlanRequestTest.php
@@ -2,7 +2,7 @@
 
 namespace Omnipay\PayPal\Message;
 
-use League\Omnipay\Tests\TestCase;
+use Omnipay\Tests\TestCase;
 use Omnipay\PayPal\RestGateway;
 
 class RestCreatePlanRequestTest extends TestCase

--- a/tests/Message/RestCreateSubscriptionRequestTest.php
+++ b/tests/Message/RestCreateSubscriptionRequestTest.php
@@ -2,7 +2,7 @@
 
 namespace Omnipay\PayPal\Message;
 
-use League\Omnipay\Tests\TestCase;
+use Omnipay\Tests\TestCase;
 use Omnipay\PayPal\RestGateway;
 
 class RestCreateSubscriptionRequestTest extends TestCase

--- a/tests/Message/RestDeleteCardRequestTest.php
+++ b/tests/Message/RestDeleteCardRequestTest.php
@@ -2,8 +2,8 @@
 
 namespace Omnipay\PayPal\Message;
 
-use League\Omnipay\Common\CreditCard;
-use League\Omnipay\Tests\TestCase;
+use Omnipay\Common\CreditCard;
+use Omnipay\Tests\TestCase;
 
 class RestDeleteCardRequestTest extends TestCase
 {

--- a/tests/Message/RestFetchPurchaseRequestTest.php
+++ b/tests/Message/RestFetchPurchaseRequestTest.php
@@ -2,7 +2,7 @@
 
 namespace Omnipay\PayPal\Message;
 
-use League\Omnipay\Tests\TestCase;
+use Omnipay\Tests\TestCase;
 
 class RestFetchPurchaseRequestTest extends TestCase
 {

--- a/tests/Message/RestFetchTransactionRequestTest.php
+++ b/tests/Message/RestFetchTransactionRequestTest.php
@@ -2,7 +2,7 @@
 
 namespace Omnipay\PayPal\Message;
 
-use League\Omnipay\Tests\TestCase;
+use Omnipay\Tests\TestCase;
 
 class RestFetchTransactionRequestTest extends TestCase
 {

--- a/tests/Message/RestPurchaseRequestTest.php
+++ b/tests/Message/RestPurchaseRequestTest.php
@@ -2,9 +2,9 @@
 
 namespace Omnipay\PayPal\Message;
 
-use League\Omnipay\Common\CreditCard;
-use League\Omnipay\Common\Customer;
-use League\Omnipay\Tests\TestCase;
+use Omnipay\Common\CreditCard;
+use Omnipay\Common\Customer;
+use Omnipay\Tests\TestCase;
 
 class RestPurchaseRequestTest extends TestCase
 {

--- a/tests/Message/RestReactivateSubscriptionRequestTest.php
+++ b/tests/Message/RestReactivateSubscriptionRequestTest.php
@@ -2,7 +2,7 @@
 
 namespace Omnipay\PayPal\Message;
 
-use League\Omnipay\Tests\TestCase;
+use Omnipay\Tests\TestCase;
 use Omnipay\PayPal\RestGateway;
 
 class RestReactivateSubscriptionRequestTest extends TestCase

--- a/tests/Message/RestResponseTest.php
+++ b/tests/Message/RestResponseTest.php
@@ -2,7 +2,7 @@
 
 namespace Omnipay\PayPal\Message;
 
-use League\Omnipay\Tests\TestCase;
+use Omnipay\Tests\TestCase;
 
 class RestResponseTest extends TestCase
 {

--- a/tests/Message/RestSearchTransactionRequestTest.php
+++ b/tests/Message/RestSearchTransactionRequestTest.php
@@ -2,7 +2,7 @@
 
 namespace Omnipay\PayPal\Message;
 
-use League\Omnipay\Tests\TestCase;
+use Omnipay\Tests\TestCase;
 use Omnipay\PayPal\RestGateway;
 
 class RestSearchTransactionRequestTest extends TestCase

--- a/tests/Message/RestSuspendSubscriptionRequestTest.php
+++ b/tests/Message/RestSuspendSubscriptionRequestTest.php
@@ -2,7 +2,7 @@
 
 namespace Omnipay\PayPal\Message;
 
-use League\Omnipay\Tests\TestCase;
+use Omnipay\Tests\TestCase;
 use Omnipay\PayPal\RestGateway;
 
 class RestSuspendSubscriptionRequestTest extends TestCase

--- a/tests/Message/RestUpdatePlanRequestTest.php
+++ b/tests/Message/RestUpdatePlanRequestTest.php
@@ -2,7 +2,7 @@
 
 namespace Omnipay\PayPal\Message;
 
-use League\Omnipay\Tests\TestCase;
+use Omnipay\Tests\TestCase;
 use Omnipay\PayPal\RestGateway;
 
 class RestUpdatePlanRequestTest extends TestCase

--- a/tests/ProGatewayTest.php
+++ b/tests/ProGatewayTest.php
@@ -2,8 +2,8 @@
 
 namespace Omnipay\PayPal;
 
-use League\Omnipay\Tests\GatewayTestCase;
-use League\Omnipay\Common\CreditCard;
+use Omnipay\Tests\GatewayTestCase;
+use Omnipay\Common\CreditCard;
 
 class ProGatewayTest extends GatewayTestCase
 {

--- a/tests/RestGatewayTest.php
+++ b/tests/RestGatewayTest.php
@@ -2,8 +2,8 @@
 
 namespace Omnipay\PayPal;
 
-use League\Omnipay\Tests\GatewayTestCase;
-use League\Omnipay\Common\CreditCard;
+use Omnipay\Tests\GatewayTestCase;
+use Omnipay\Common\CreditCard;
 
 class RestGatewayTest extends GatewayTestCase
 {


### PR DESCRIPTION
Generally I am confused a bit as to where `thephpleague:3.0` relates to. It seems to be incompatible with https://github.com/thephpleague/omnipay-common/tree/v3.0-alpha.1.
https://github.com/thephpleague/omnipay-common/tree/future looks almost closer to what is actually needed.


@barryvdh if you could shed some light regarding the way forward I am more than happy to help out a bit.
I was trying to use the paypal gateway in a project but since it is in Laravel 5.5 I need to require omnipay v3 and it's causing some trouble. 
We are also busy implementing omnipay gateways for Pesapal, MPower and Paystack. Looking forward to giving something back to the community.