### PR TITLE
Allow negative amount for items

### DIFF
--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -38,6 +38,11 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
 
     protected $liveEndpoint = 'https://api-3t.paypal.com/nvp';
     protected $testEndpoint = 'https://api-3t.sandbox.paypal.com/nvp';
+    
+    /**
+     * @var bool
+     */
+    protected $negativeAmountAllowed = true;
 
     public function getUsername()
     {


### PR DESCRIPTION
At PayPal items can be negativ. We need to allow negativ amounts