### PR TITLE
Authentication fix for getting a REST gateway access token

### DIFF
--- a/src/Message/RestTokenRequest.php
+++ b/src/Message/RestTokenRequest.php
@@ -36,7 +36,7 @@ class RestTokenRequest extends AbstractRestRequest
             $this->getEndpoint(),
             array(
                 'Accept' => 'application/json',
-                'Authorization' => 'Bearer ' . base64_encode("{$this->getClientId()}:{$this->getSecret()}"),
+                'Authorization' => 'Basic ' . base64_encode("{$this->getClientId()}:{$this->getSecret()}"),
             ),
             $body
         );


### PR DESCRIPTION
Currently REST gateway calls will fail, because the gateway is unable to fetch a valid access token. 

The `/oauth2/token` endpoint expects a Authentication Basic header [(docs)](https://developer.paypal.com/docs/api/overview/#get-an-access-token).

Tested in production.