### PR TITLE
Add capture action.

### DIFF
--- a/src/ExpressGateway.php
+++ b/src/ExpressGateway.php
@@ -133,6 +133,11 @@ class ExpressGateway extends ProGateway
         return $this->authorize($parameters);
     }
 
+    public function capture(array $parameters = array())
+    {
+        return $this->createRequest('\Omnipay\PayPal\Message\ExpressCaptureRequest', $parameters);
+    }
+
     public function completePurchase(array $parameters = array())
     {
         return $this->createRequest('\Omnipay\PayPal\Message\ExpressCompletePurchaseRequest', $parameters);

--- a/src/Message/ExpressCaptureRequest.php
+++ b/src/Message/ExpressCaptureRequest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Omnipay\PayPal\Message;
+
+/**
+ * PayPal Express Capture Request
+ */
+class ExpressCaptureRequest extends ExpressCompletePurchaseRequest
+{
+    public function getData()
+    {
+
+        $data = parent::getData();
+        $data['TOKEN'] = $this->getTransactionReference();
+        return $data;
+    }
+
+    protected function createResponse($data)
+    {
+        return $this->response = new ExpressCaptureResponse($this, $data);
+    }
+}

--- a/src/Message/ExpressCaptureResponse.php
+++ b/src/Message/ExpressCaptureResponse.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Omnipay\PayPal\Message;
+
+/**
+ * PayPal Express Capture Response
+ */
+class ExpressCaptureResponse extends ExpressCompletePurchaseResponse
+{
+}


### PR DESCRIPTION
The current actions for paypal express don't seem to map quite correctly to the standard.

Notably the CompletePurchase action would normally mean 'respond to incoming notification that
the purchase has successfully completed' (aka an ipn). However, here it is being used to Capture
a previously authorised transaction.

Since there is no capture action and that is the normal name for the action to 'capture' previously
authorised transactions I think it makes sense to add it.

Note that the normal usage would to set a cardReference where we have a token. Since this is
a new action I was able to do that minor change in the new action.

The concept of 'authorize' in expressCheckout is not quite the same as a 'normal
authorize' - in that the funds have been approved (as per normal) but not reserved on the card,
but I feel it's stil in principle an authorize-capture flow.