### PR TITLE
Refine handling of 'card' parameter to support generic integrations.

### DIFF
--- a/src/Message/RestAuthorizeRequest.php
+++ b/src/Message/RestAuthorizeRequest.php
@@ -5,6 +5,8 @@
 
 namespace Omnipay\PayPal\Message;
 
+use Omnipay\Common\Exception\InvalidCreditCardException;
+
 /**
  * PayPal REST Authorize Request
  *
@@ -259,9 +261,8 @@ class RestAuthorizeRequest extends AbstractRestRequest
                     'credit_card_id' => $this->getCardReference(),
                 ),
             );
-        } elseif ($this->getCard()) {
+        } elseif ($this->validCardPresent()) {
             $this->validate('amount', 'card');
-            $this->getCard()->validate();
 
             $data['payer']['funding_instruments'][] = array(
                 'credit_card' => array(
@@ -302,6 +303,31 @@ class RestAuthorizeRequest extends AbstractRestRequest
         }
 
         return $data;
+    }
+
+  /**
+   * Has a valid card been passed in the Omnipay parameters.
+   *
+   * Omnipay supports details other than card details in the card parameter (e.g.
+   * billing address) so a generic omnipay integration might set the 'card' when
+   * there is no number present. In which case the Rest integration should fall
+   * back to the next method.
+   */
+    public function validCardPresent()
+    {
+        if (!$this->getCard() || !$this->getCard()->getNumber()) {
+            return false;
+        }
+        try {
+            $this->getCard()->validate();
+        } catch (\Omnipay\Common\Exception\InvalidCreditCardException $e) {
+            if (stristr($e->getMessage(), 'parameter is required')) {
+                return false;
+            } else {
+                throw $e;
+            }
+        }
+        return true;
     }
 
     /**


### PR DESCRIPTION
Check that the card parameter actually holds card details before going into the loop for handling a situation where card details are present.

In a generic integration the card parameter might exist to hold billing address details even when
the card number is not provided. 

We don't expect the integration to hold knowledge that 'paypal rest won't work
if you pass a 'card' paramter when you are pre-authorizing a token' so we should
look more deeply into the passed card parameter for the presence of the actual card fields - ie.
card number, expiry ,cvv