### PR TITLE
Refine handling of 'card' parameter to support generic integrations.

### DIFF
--- a/tests/Mock/RestGenericSubscriptionSuccess.txt
+++ b/tests/Mock/RestGenericSubscriptionSuccess.txt
@@ -5,3 +5,4 @@ Paypal-Debug-Id: 217a9ddefd384
 SERVER_INFO: identitysecuretokenserv:v1.oauth2.token&CalThreadId=91&TopLevelTxnStartTime=146fbfe679a&Host=slcsbidensectoken502.slc.paypal.com&pid=29059
 CORRELATION-ID: 217a9ddefd384
 Date: Thu, 03 Jul 2014 11:31:32 GMT
+


### PR DESCRIPTION
When setting up a paypal rest Authorize request there are a few possibilities

1) we have a payment token
2) we have a credit card number & cvv & expiry
3) we have neither of the above and should be redirected to paypal for us to log in and authorize the payment.

Currently the code understands the difference as 
1) cardReference is present
2) 'card' object is present
3) neither of the above.

However, the card object also holds other information - email, address, phone etc. Even if these are not used by Paypal Rest the calling code should not need to know that it can't set these under a specific combination of circumstances.

This fix looks  more deeply into the passed card parameter for the presence of the actual card fields - ie.card number, expiry  - and otherwise concludes this is not a card-present transations and allows the redirect to proceed

