### PR TITLE
Adds content to the success message mock

### DIFF
--- a/tests/Mock/RestGenericSubscriptionSuccess.txt
+++ b/tests/Mock/RestGenericSubscriptionSuccess.txt
@@ -5,3 +5,5 @@ Paypal-Debug-Id: 217a9ddefd384
 SERVER_INFO: identitysecuretokenserv:v1.oauth2.token&CalThreadId=91&TopLevelTxnStartTime=146fbfe679a&Host=slcsbidensectoken502.slc.paypal.com&pid=29059
 CORRELATION-ID: 217a9ddefd384
 Date: Thu, 03 Jul 2014 11:31:32 GMT
+
+{}


### PR DESCRIPTION
`GuzzleHttp\Psr7\_parse_message` isn't able to parse `RestGenericSubscriptionSuccess.txt` because the message has no content in `RestGatewayTest` (https://travis-ci.org/thephpleague/omnipay-paypal/jobs/489941682#L601). This PR adds content to the message so the tests no longer fail.