### PR TITLE
#216 Add support for referrer code to Rest Gateway

### DIFF
--- a/src/Message/AbstractRestRequest.php
+++ b/src/Message/AbstractRestRequest.php
@@ -62,6 +62,24 @@ abstract class AbstractRestRequest extends \Omnipay\Common\Message\AbstractReque
      */
     protected $payerId = null;
 
+    protected $referrerCode;
+
+    /**
+     * @return string
+     */
+    public function getReferrerCode()
+    {
+        return $this->referrerCode;
+    }
+
+    /**
+     * @param string $referrerCode
+     */
+    public function setReferrerCode($referrerCode)
+    {
+        $this->referrerCode = $referrerCode;
+    }
+
     public function getClientId()
     {
         return $this->getParameter('clientId');
@@ -146,6 +164,7 @@ abstract class AbstractRestRequest extends \Omnipay\Common\Message\AbstractReque
                     'Accept' => 'application/json',
                     'Authorization' => 'Bearer ' . $this->getToken(),
                     'Content-type' => 'application/json',
+                    'PayPal-Partner-Attribution-Id' => $this->getReferrerCode(),
                 ),
                 $body
             );


### PR DESCRIPTION
Referrer code is otherwise called BNCode or partner attribution id in paypal-land.
I chose referrer code as something generic

https://developer.paypal.com/docs/integration/direct/payments/#