### PR TITLE
allow negative items for REST API

### DIFF
--- a/src/Message/AbstractRestRequest.php
+++ b/src/Message/AbstractRestRequest.php
@@ -65,6 +65,11 @@ abstract class AbstractRestRequest extends \Omnipay\Common\Message\AbstractReque
     protected $referrerCode;
 
     /**
+     * @var bool
+     */
+    protected $negativeAmountAllowed = true;
+    
+    /**
      * @return string
      */
     public function getReferrerCode()


### PR DESCRIPTION
Allow negative Amount Items for REST Api too same as for the other API like here requested: https://github.com/thephpleague/omnipay-paypal/pull/198