### PR TITLE
Update ExpressTransactionSearchRequest.php

### DIFF
--- a/src/Message/ExpressTransactionSearchRequest.php
+++ b/src/Message/ExpressTransactionSearchRequest.php
@@ -366,6 +366,7 @@ class ExpressTransactionSearchRequest extends AbstractRequest
      */
     public function createResponse($data)
     {
+        unset($data['payments']);
         return $this->response = new ExpressTransactionSearchResponse($this, $data);
     }
 }


### PR DESCRIPTION
when 100 results are returned. There is also a empty 'payments' key. This key pushes the $data array to 1001 input vars which causes php issues when passed to parse_str in AbstractResponse. Best option seems to be just unset the empty key and get back to max 1000 keys in the data array.